### PR TITLE
Add `ember try:fastboot`

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,7 @@
 # compiled output
 /dist
 /tmp
+/fastboot-dist
 
 # dependencies
 /node_modules

--- a/README.md
+++ b/README.md
@@ -62,6 +62,12 @@ In order to use an alternate config path or to group various scenarios, you can 
 ```
 
 
+#### `ember try:fastboot`
+
+This command installs `ember-cli-fastboot` and attempts to run `ember fastboot`, to determine FastBoot compatibility.
+There is one option, `timeout` (Default: 30000), which is used to determine success. If `ember fastboot` successfully 
+starts up a sever, this command waits until the timeout to declare success.
+
 #### `ember try:reset`
 
 This command restores the original `bower.json` from `bower.json.ember-try`, `rm -rf`s `bower_components` and runs `bower install`. For use if any of the other commands fail to clean up after (they run this by default on completion).

--- a/lib/commands/fastboot.js
+++ b/lib/commands/fastboot.js
@@ -1,0 +1,35 @@
+'use strict';
+
+module.exports = {
+  name: 'try:fastboot',
+  description: 'Tests whether the project is FastBoot Compatible' ,
+  works: 'insideProject',
+  availableOptions: [
+    { name: 'timeout', type: Number, default: 30000 }
+  ],
+
+  _NpmAdapter: require('../utils/npm-adapter'),
+  _TryEachTask: require('../tasks/try-each'),
+
+  run: function(commandOptions) {
+
+    var dependencyManagerAdapter = new this._NpmAdapter({cwd: this.project.root});
+    var tryEachTask = new this._TryEachTask({
+      ui: this.ui,
+      project: this.project,
+      dependencyManagerAdapters: [dependencyManagerAdapter],
+      commandArgs: ['fastboot'],
+      commandOptions: { timeout: { length: commandOptions.timeout, isSuccess: true }}
+    });
+
+    var fastbootScenario = {
+      name: 'fastboot',
+      npm: {
+        devDependencies: {
+          'ember-cli-fastboot': '>=0.3.4'
+        }
+      }
+    };
+    return tryEachTask.run([fastbootScenario]);
+  }
+};

--- a/lib/commands/index.js
+++ b/lib/commands/index.js
@@ -1,5 +1,6 @@
 module.exports = {
   try:         require('./try'),
   'try:testall': require('./testall'),
-  'try:reset':   require('./reset')
+  'try:reset':   require('./reset'),
+  'try:fastboot': require('./fastboot')
 };

--- a/lib/tasks/reset.js
+++ b/lib/tasks/reset.js
@@ -5,7 +5,7 @@ var DependencyManagerAdapterFactory = require('./../utils/dependency-manager-ada
 
 module.exports = CoreObject.extend({
   run: function() {
-    var dependencyAdapters = this.dependencyManagerAdapters || DependencyManagerAdapterFactory.generate(this.config, this.project.root);
+    var dependencyAdapters = this.dependencyManagerAdapters || DependencyManagerAdapterFactory.generateFromConfig(this.config, this.project.root);
     return new ScenarioManager({ dependencyManagerAdapters: dependencyAdapters }).cleanup();
   }
 });

--- a/lib/tasks/reset.js
+++ b/lib/tasks/reset.js
@@ -1,9 +1,11 @@
 'use strict';
 var CoreObject      = require('core-object');
 var ScenarioManager = require('../utils/scenario-manager');
+var DependencyManagerAdapterFactory = require('./../utils/dependency-manager-adapter-factory');
 
 module.exports = CoreObject.extend({
   run: function() {
-    return new ScenarioManager({project: this.project, config: this.config}).cleanup();
+    var dependencyAdapters = this.dependencyManagerAdapters || DependencyManagerAdapterFactory.generate(this.config, this.project.root);
+    return new ScenarioManager({ dependencyManagerAdapters: dependencyAdapters }).cleanup();
   }
 });

--- a/lib/tasks/try-each.js
+++ b/lib/tasks/try-each.js
@@ -11,16 +11,23 @@ var DependencyManagerAdapterFactory = require('./../utils/dependency-manager-ada
 module.exports = CoreObject.extend({
   run: function(scenarios, options) {
     var task = this;
-    var dependencyManagerAdapters = task.dependencyManagerAdapters || DependencyManagerAdapterFactory.generate(task.config, task.project.root);
+    var dependencyManagerAdapters = task.dependencyManagerAdapters || DependencyManagerAdapterFactory.generateFromConfig(task.config, task.project.root);
     task.ScenarioManager = new ScenarioManager({ui: task.ui,
                                                 dependencyManagerAdapters: dependencyManagerAdapters
     });
 
+    var shutdownCount = 0;
     process.on('SIGINT', function() {
-      task.ui.writeLine('\nGracefully shutting down from SIGINT (Ctrl-C)');
-      return task.ScenarioManager.cleanup().then(function() {
+      if (shutdownCount === 0) {
+        shutdownCount++;
+        task.ui.writeLine('\nGracefully shutting down from SIGINT (Ctrl-C)');
+        return task.ScenarioManager.cleanup().then(function() {
+          task._exit();
+        });
+      } else {
+        task.ui.writeLine('\nOk, but it\'s going to be a mess');
         task._exit();
-      });
+      }
     });
 
     return task.ScenarioManager.setup().then(function() {
@@ -59,7 +66,11 @@ module.exports = CoreObject.extend({
 
   _runCommand: function() {
     var task = this;
-    return runCommand(task.project.root, this._commandArgs());
+    return runCommand(task.project.root, this._commandArgs(), this._commandOptions());
+  },
+
+  _commandOptions: function() {
+    return this.commandOptions;
   },
 
   _commandArgs: function() {
@@ -82,7 +93,7 @@ module.exports = CoreObject.extend({
 
     var task = this;
     var promise;
-    if (options.skipCleanup) {
+    if (options && options.skipCleanup) {
       // Create a fake promise for consistency
       promise = RSVP.Promise.resolve();
     } else {

--- a/lib/tasks/try-each.js
+++ b/lib/tasks/try-each.js
@@ -6,15 +6,14 @@ var chalk           = require('chalk');
 var ScenarioManager = require('./../utils/scenario-manager');
 var runCommand      = require('./../utils/run-command');
 var ResultSummary   = require('./../utils/result-summary');
+var DependencyManagerAdapterFactory = require('./../utils/dependency-manager-adapter-factory');
 
 module.exports = CoreObject.extend({
   run: function(scenarios, options) {
     var task = this;
-
+    var dependencyManagerAdapters = task.dependencyManagerAdapters || DependencyManagerAdapterFactory.generate(task.config, task.project.root);
     task.ScenarioManager = new ScenarioManager({ui: task.ui,
-                                                project: task.project,
-                                                config: task.config,
-                                                dependencyManagerAdapters: task.dependencyManagerAdapters
+                                                dependencyManagerAdapters: dependencyManagerAdapters
     });
 
     process.on('SIGINT', function() {

--- a/lib/utils/dependency-manager-adapter-factory.js
+++ b/lib/utils/dependency-manager-adapter-factory.js
@@ -2,11 +2,11 @@ var BowerAdapter = require('./bower-adapter');
 var NpmAdapter   = require('./npm-adapter');
 
 module.exports = {
-  generate: function(config, root) {
+  generateFromConfig: function(config, root) {
     var hasNpm = false;
     var hasBower = false;
     var adapters = [];
-    if(!config || !config.scenarios) {
+    if (!config || !config.scenarios) {
       return [];
     }
 

--- a/lib/utils/dependency-manager-adapter-factory.js
+++ b/lib/utils/dependency-manager-adapter-factory.js
@@ -1,0 +1,29 @@
+var BowerAdapter = require('./bower-adapter');
+var NpmAdapter   = require('./npm-adapter');
+
+module.exports = {
+  generate: function(config, root) {
+    var hasNpm = false;
+    var hasBower = false;
+    var adapters = [];
+    if(!config || !config.scenarios) {
+      return [];
+    }
+
+    config.scenarios.forEach(function(scenario) {
+      if (scenario.npm) {
+        hasNpm = true;
+      }
+      if (scenario.bower || scenario.dependencies || scenario.devDependencies) {
+        hasBower = true;
+      }
+    });
+    if (hasNpm) {
+      adapters.push(new NpmAdapter({cwd: root}));
+    }
+    if (hasBower) {
+      adapters.push(new BowerAdapter({cwd: root}));
+    }
+    return adapters;
+  }
+};

--- a/lib/utils/run-command.js
+++ b/lib/utils/run-command.js
@@ -1,11 +1,14 @@
 var RSVP          = require('rsvp');
+var extend        = require('extend');
 var findEmberPath = require('./find-ember-path');
 var run           = require('./run');
 
-module.exports = function(root, commandArgs) {
+module.exports = function(root, commandArgs, opts) {
+  var options;
   return findEmberPath(root)
     .then(function(emberPath) {
-      return run('node', [emberPath, commandArgs], {cwd: root});
+      options = extend({cwd: root}, opts);
+      return run('node', [emberPath, commandArgs], options);
     })
     .then(function() {
       return RSVP.resolve(true);

--- a/lib/utils/run.js
+++ b/lib/utils/run.js
@@ -6,11 +6,26 @@ function run(command, args, opts) {
   opts.stdio = 'inherit';
   return new RSVP.Promise(function(resolve, reject) {
     var p = spawn(command, args, opts);
+    var didTimeout = false;
+    if (opts.timeout) {
+      setTimeout(function() {
+        didTimeout = true;
+        p.kill();
+        if (opts.timeout.isSuccess) {
+          resolve();
+        } else {
+          reject(1);
+        }
+      }, opts.timeout.length || 1000);
+    }
+
     p.on('close', function(code) {
-      if (code !== 0) {
-        reject(code);
-      } else {
-        resolve();
+      if (!didTimeout) {
+        if (code !== 0) {
+          reject(code);
+        } else {
+          resolve();
+        }
       }
     });
   });

--- a/lib/utils/scenario-manager.js
+++ b/lib/utils/scenario-manager.js
@@ -7,30 +7,12 @@ var NpmAdapter   = require('./npm-adapter');
 module.exports = CoreObject.extend({
   init: function() {
     this._super.apply(this, arguments);
-    this._initDependencyManagerAdapters();
+    this._checkDependencyManagerAdapters();
   },
 
-  _initDependencyManagerAdapters: function() {
-    if (this.dependencyManagerAdapters && this.dependencyManagerAdapters.length > 0) { return; }
-    var hasNpm = false;
-    var hasBower = false;
-    this.config.scenarios.forEach(function(scenario) {
-      if (scenario.npm) {
-        hasNpm = true;
-      }
-      if (scenario.bower || scenario.dependencies || scenario.devDependencies) {
-        hasBower = true;
-      }
-    });
-    this.dependencyManagerAdapters = [];
-    if (hasNpm) {
-      this.dependencyManagerAdapters.push(new NpmAdapter({cwd: this.project.root}));
-    }
-    if (hasBower) {
-      this.dependencyManagerAdapters.push(new BowerAdapter({cwd: this.project.root}));
-    }
-    if (this.dependencyManagerAdapters.length === 0) {
-      throw new Error('No dependency manager adapter created');
+  _checkDependencyManagerAdapters: function() {
+    if (!this.dependencyManagerAdapters || this.dependencyManagerAdapters.length === 0) {
+      throw new Error('No dependency manager adapter');
     }
   },
 

--- a/test/dependency-manager-adapter-factory-test.js
+++ b/test/dependency-manager-adapter-factory-test.js
@@ -1,0 +1,37 @@
+var DependencyManagerAdapterFactory = require('../lib/utils/dependency-manager-adapter-factory');
+var should = require('should');
+
+describe('DependencyManagerAdapterFactory', function() {
+  describe('generate', function() {
+    it('creates npm adapter when config has npm key', function() {
+      var adapters = DependencyManagerAdapterFactory.generate({ scenarios: [{ npm: {} }]}, 'here');
+      adapters[0].configKey.should.equal('npm');
+      adapters.length.should.equal(1);
+    });
+
+    it('creates bower adapter when config has bower key', function() {
+      var adapters = DependencyManagerAdapterFactory.generate({ scenarios: [{ bower: {} }]}, 'here');
+      adapters[0].configKey.should.equal('bower');
+      adapters.length.should.equal(1);
+    });
+
+    it('creates both adapters when it has both keys', function() {
+      var adapters = DependencyManagerAdapterFactory.generate({ scenarios: [{ bower: {}, npm: {}}]}, 'here');
+      adapters[0].configKey.should.equal('npm');
+      adapters[1].configKey.should.equal('bower');
+      adapters.length.should.equal(2);
+    });
+
+    it('creates bower adapter when legacy dependenies key', function() {
+      var adapters = DependencyManagerAdapterFactory.generate({ scenarios: [{ dependencies: {}}]}, 'here');
+      adapters[0].configKey.should.equal('bower');
+      adapters.length.should.equal(1);
+    });
+
+    it('creates bower adapter when legacy devDependencies key', function() {
+      var adapters = DependencyManagerAdapterFactory.generate({ scenarios: [{ devDependencies: {}}]}, 'here');
+      adapters[0].configKey.should.equal('bower');
+      adapters.length.should.equal(1);
+    });
+  });
+});

--- a/test/dependency-manager-adapter-factory-test.js
+++ b/test/dependency-manager-adapter-factory-test.js
@@ -2,34 +2,34 @@ var DependencyManagerAdapterFactory = require('../lib/utils/dependency-manager-a
 var should = require('should');
 
 describe('DependencyManagerAdapterFactory', function() {
-  describe('generate', function() {
+  describe('generateFromConfig', function() {
     it('creates npm adapter when config has npm key', function() {
-      var adapters = DependencyManagerAdapterFactory.generate({ scenarios: [{ npm: {} }]}, 'here');
+      var adapters = DependencyManagerAdapterFactory.generateFromConfig({ scenarios: [{ npm: {} }]}, 'here');
       adapters[0].configKey.should.equal('npm');
       adapters.length.should.equal(1);
     });
 
     it('creates bower adapter when config has bower key', function() {
-      var adapters = DependencyManagerAdapterFactory.generate({ scenarios: [{ bower: {} }]}, 'here');
+      var adapters = DependencyManagerAdapterFactory.generateFromConfig({ scenarios: [{ bower: {} }]}, 'here');
       adapters[0].configKey.should.equal('bower');
       adapters.length.should.equal(1);
     });
 
     it('creates both adapters when it has both keys', function() {
-      var adapters = DependencyManagerAdapterFactory.generate({ scenarios: [{ bower: {}, npm: {}}]}, 'here');
+      var adapters = DependencyManagerAdapterFactory.generateFromConfig({ scenarios: [{ bower: {}, npm: {}}]}, 'here');
       adapters[0].configKey.should.equal('npm');
       adapters[1].configKey.should.equal('bower');
       adapters.length.should.equal(2);
     });
 
     it('creates bower adapter when legacy dependenies key', function() {
-      var adapters = DependencyManagerAdapterFactory.generate({ scenarios: [{ dependencies: {}}]}, 'here');
+      var adapters = DependencyManagerAdapterFactory.generateFromConfig({ scenarios: [{ dependencies: {}}]}, 'here');
       adapters[0].configKey.should.equal('bower');
       adapters.length.should.equal(1);
     });
 
     it('creates bower adapter when legacy devDependencies key', function() {
-      var adapters = DependencyManagerAdapterFactory.generate({ scenarios: [{ devDependencies: {}}]}, 'here');
+      var adapters = DependencyManagerAdapterFactory.generateFromConfig({ scenarios: [{ devDependencies: {}}]}, 'here');
       adapters[0].configKey.should.equal('bower');
       adapters.length.should.equal(1);
     });

--- a/test/scenario-manager-test.js
+++ b/test/scenario-manager-test.js
@@ -4,40 +4,6 @@ var RSVP = require('rsvp');
 var should = require('should');
 
 describe('scenarioManager', function() {
-  describe('new', function() {
-    describe('dependency manager adapter creation', function() {
-      it('creates npm adapter when config has npm key', function() {
-        var manager = new ScenarioManager({ config: { scenarios: [{ npm: {} }]}, project: {root: 'here'}});
-        manager.dependencyManagerAdapters[0].configKey.should.equal('npm');
-        manager.dependencyManagerAdapters.length.should.equal(1);
-      });
-
-      it('creates bower adapter when config has bower key', function() {
-        var manager = new ScenarioManager({ config: { scenarios: [{ bower: {} }]}, project: {root: 'here'}});
-        manager.dependencyManagerAdapters[0].configKey.should.equal('bower');
-        manager.dependencyManagerAdapters.length.should.equal(1);
-      });
-
-      it('creates both adapters when it has both keys', function() {
-        var manager = new ScenarioManager({ config: { scenarios: [{ bower: {}, npm: {}}]}, project: {root: 'here'}});
-        manager.dependencyManagerAdapters[0].configKey.should.equal('npm');
-        manager.dependencyManagerAdapters[1].configKey.should.equal('bower');
-        manager.dependencyManagerAdapters.length.should.equal(2);
-      });
-
-      it('creates bower adapter when legacy dependenies key', function() {
-        var manager = new ScenarioManager({ config: { scenarios: [{ dependencies: {}}]}, project: {root: 'here'}});
-        manager.dependencyManagerAdapters[0].configKey.should.equal('bower');
-        manager.dependencyManagerAdapters.length.should.equal(1);
-      });
-
-      it('creates bower adapter when legacy devDependencies key', function() {
-        var manager = new ScenarioManager({ config: { scenarios: [{ devDependencies: {}}]}, project: {root: 'here'}});
-        manager.dependencyManagerAdapters[0].configKey.should.equal('bower');
-        manager.dependencyManagerAdapters.length.should.equal(1);
-      });
-    });
-  });
 
   describe('#setup', function() {
     it('sets up each of the dependency managers', function() {


### PR DESCRIPTION
It installs ember-cli-fastboot, runs `ember fastboot`, then waits for the command to either exit or hit the timeout (Default 30s). Hitting the timeout means the command has succeeded in starting up a server, so this timeout may need to be adjusted longer for apps or addons with long build times.

Potential future improvements: We could separately run `ember fastboot:build` and `ember fastboot` to avoid more possible false success scenarios (when the timeout occurs before the server has started up). 
