### PR TITLE
Fix deprecation message for `ember try` command.

### DIFF
--- a/lib/commands/try.js
+++ b/lib/commands/try.js
@@ -46,7 +46,7 @@ module.exports = {
 
   run: function(commandOptions, rawArgs) {
     var tryCmd = this;
-    tryCmd.ui.writeDeprecateLine('tryCmd command is deprecated in favor of `ember try:one`.\nExample: `ember try default-scenario serve --port 4201`, becomes:\n`ember try:one default-scenario --- ember serve --port 4201`');
+    tryCmd.ui.writeDeprecateLine('The `ember try` command is deprecated in favor of `ember try:one`.\nExample: `ember try default-scenario serve --port 4201`, becomes:\n`ember try:one default-scenario --- ember serve --port 4201`');
     var scenarioName = rawArgs[0];
 
     var commandArgs = tryCmd.getCommand();


### PR DESCRIPTION
Prior to this change the message looked like:

```
DEPRECATION: tryCmd command is deprecated in favor of `ember try:one`.
```

Making `tryCmd`  be `ember try` (as is done here) emits the following:

```
DEPRECATION: The `ember try` command is deprecated in favor of `ember try:one`.
```