### PR TITLE
Move costly requires to be lazy.

### DIFF
--- a/lib/tasks/try-each.js
+++ b/lib/tasks/try-each.js
@@ -4,13 +4,14 @@ var RSVP            = require('rsvp');
 var mapSeries       = require('promise-map-series');
 var chalk           = require('chalk');
 var debug           = require('debug')('ember-try:task:try-each');
-var ScenarioManager = require('./../utils/scenario-manager');
 var runCommand      = require('./../utils/run-command');
-var ResultSummary   = require('./../utils/result-summary');
-var DependencyManagerAdapterFactory = require('./../utils/dependency-manager-adapter-factory');
 
 module.exports = CoreObject.extend({
   run: function(scenarios, options) {
+    // Required lazily to improve startup speed.
+    var ScenarioManager = require('./../utils/scenario-manager');
+    var DependencyManagerAdapterFactory = require('./../utils/dependency-manager-adapter-factory');
+
     var task = this;
     var dependencyManagerAdapters = task.dependencyManagerAdapters || DependencyManagerAdapterFactory.generateFromConfig(task.config, task.project.root);
     debug('DependencyManagerAdapters: %s', dependencyManagerAdapters.map(function(item) { return item.configKey; }));
@@ -119,6 +120,9 @@ module.exports = CoreObject.extend({
   },
 
   _printResults: function(results) {
+    // Required lazily to improve startup speed.
+    var ResultSummary   = require('./../utils/result-summary');
+
     new ResultSummary({ui: this.ui, results: results}).print();
   },
 

--- a/lib/utils/config.js
+++ b/lib/utils/config.js
@@ -4,7 +4,6 @@ var path = require('path');
 var fs = require('fs');
 var extend = require('extend');
 var RSVP = require('rsvp');
-var autoScenarioConfigForEmber = require('ember-try-config');
 var findByName = require('./find-by-name');
 
 function config(options) {
@@ -27,6 +26,8 @@ function config(options) {
   var versionCompatibility = options.versionCompatibility || versionCompatibilityFromPackageJSON(options.project.root);
 
   if (versionCompatibility) {
+    // Required lazily to improve startup speed.
+    var autoScenarioConfigForEmber = require('ember-try-config');
     return autoScenarioConfigForEmber({versionCompatibility: versionCompatibility, project: options.project}).then(function(autoConfig) {
       return mergeAutoConfigAndConfigFileData(autoConfig, configData);
     });


### PR DESCRIPTION
Before:

```
% ember v
...snip...
        4.95 real         1.18 user         0.18 sys
```

After:

```
% ember v
...snip...
        2.09 real         1.34 user         0.27 sys
```

Fixes #74