### PR TITLE
Don't use "latest" as strategy in package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -60,7 +60,7 @@
     "core-object": "^1.1.0",
     "debug": "^2.2.0",
     "ember-cli-babel": "^5.1.3",
-    "ember-try-config": "latest",
+    "ember-try-config": "^2.0.1",
     "extend": "^3.0.0",
     "fs-extra": "^0.26.0",
     "promise-map-series": "^0.2.1",


### PR DESCRIPTION
"latest" as a version is a source of problems when using along with shrinkwrap, and since now ember-try is part of ember-cli, this is transitively making ember-cli a true pain to use.