### PR TITLE
Adding shell option to npm task runner spawn npm.cmd issue

### DIFF
--- a/lib/dependency-manager-adapters/npm.js
+++ b/lib/dependency-manager-adapters/npm.js
@@ -79,9 +79,9 @@ module.exports = CoreObject.extend({
 
     debug('Run npm install with options %s', options);
 
-    return adapter.run('npm', [].concat(['install'], options), {cwd: adapter.cwd}).then(function() {
+    return adapter.run('npm', [].concat(['install'], options), {cwd: adapter.cwd, shell: true}).then(function() {
       debug('Run npm prune');
-      return adapter.run('npm', [].concat(['prune'], options), {cwd: adapter.cwd});
+      return adapter.run('npm', [].concat(['prune'], options), {cwd: adapter.cwd, shell: true});
     });
   },
   _packageJSONForDependencySet: function(packageJSON, depSet) {


### PR DESCRIPTION
When running on Windows, `ember-try` is unable to spawn `npm` tasks (I think due to https://github.com/nodejs/node-v0.x-archive/issues/2318). I was able to find some Node documentation that pointed out using a `shell` option (https://nodejs.org/api/child_process.html#child_process_spawning_bat_and_cmd_files_on_windows), and that fixes the issue.
