### PR TITLE
Skipping deprecation warning if ember-cli is below 2.6

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,11 +1,17 @@
 /* jshint node: true */
 'use strict';
 
+var VersionChecker = require('ember-cli-version-checker');
+
 module.exports = {
   name: 'ember-try',
   init: function() {
     this._super.init && this._super.init.apply(this, arguments);
-    if (this.project.pkg.devDependencies && this.project.pkg.devDependencies['ember-try']) {
+
+    var checker = new VersionChecker(this);
+    var cliVersion = checker.for('ember-cli', 'npm');
+
+    if (cliVersion.satisfies('>= 2.6.0') && this.project.pkg.devDependencies && this.project.pkg.devDependencies['ember-try']) {
       this.ui.writeDeprecateLine('ember-try is now included with ember-cli. Including it in your package.json is unnecessary.');
     }
   },

--- a/package.json
+++ b/package.json
@@ -60,6 +60,7 @@
     "core-object": "^1.1.0",
     "debug": "^2.2.0",
     "ember-cli-babel": "^5.1.3",
+    "ember-cli-version-checker": "^1.1.6",
     "ember-try-config": "^2.0.1",
     "extend": "^3.0.0",
     "fs-extra": "^0.26.0",


### PR DESCRIPTION
I have an old project running `ember-cli@2.5.x` that I haven't had a chance to update yet (soon!), and I was getting deprecation warnings about ember-try being included in ember-cli, but it seems that didn't happen until `ember-cli@2.6.0`. I've added a condition checking the ember-cli version around the deprecation message.

Fixes #83.