### PR TITLE
add support for npm peerDependencies

### DIFF
--- a/lib/dependency-manager-adapters/npm.js
+++ b/lib/dependency-manager-adapters/npm.js
@@ -88,6 +88,7 @@ module.exports = CoreObject.extend({
 
     this._overridePackageJSONDependencies(packageJSON, depSet, 'dependencies');
     this._overridePackageJSONDependencies(packageJSON, depSet, 'devDependencies');
+    this._overridePackageJSONDependencies(packageJSON, depSet, 'peerDependencies');
 
     return packageJSON;
   },

--- a/test/dependency-manager-adapters/npm-adapter-test.js
+++ b/test/dependency-manager-adapters/npm-adapter-test.js
@@ -131,6 +131,16 @@ describe('npmAdapter', function() {
 
       expect(resultJSON.devDependencies['ember-feature-flags']).to.equal('2.0.1');
     });
+
+    it('changes specified npm peer dependency versions', function() {
+      var npmAdapter = new NpmAdapter({cwd: tmpdir});
+      var packageJSON = { peerDependencies: { 'ember-cli-babel': '5.0.0' } };
+      var depSet = { peerDependencies: { 'ember-cli-babel': '4.0.0' } };
+
+      var resultJSON = npmAdapter._packageJSONForDependencySet(packageJSON, depSet);
+
+      expect(resultJSON.peerDependencies['ember-cli-babel']).to.equal('4.0.0');
+    });
   });
 });
 

--- a/test/dependency-manager-adapters/npm-adapter-test.js
+++ b/test/dependency-manager-adapters/npm-adapter-test.js
@@ -115,17 +115,17 @@ describe('npmAdapter', function() {
     it('changes specified dependency versions', function() {
       var npmAdapter = new NpmAdapter({cwd: tmpdir});
       var packageJSON = { devDependencies: { 'ember-feature-flags': '1.0.0' }, dependencies: { 'ember-cli-babel': '5.0.0'} };
-      var depSet =  { dependencies: { 'ember-cli-babel': '6.0.0' } };
+      var depSet = { dependencies: { 'ember-cli-babel': '6.0.0' } };
 
       var resultJSON = npmAdapter._packageJSONForDependencySet(packageJSON, depSet);
 
       expect(resultJSON.dependencies['ember-cli-babel']).to.equal('6.0.0');
     });
 
-    it('changes specified bower dev dependency versions', function() {
+    it('changes specified npm dev dependency versions', function() {
       var npmAdapter = new NpmAdapter({cwd: tmpdir});
       var packageJSON = { devDependencies: { 'ember-feature-flags': '1.0.0' }, dependencies: { 'ember-cli-babel': '5.0.0'} };
-      var depSet =  { devDependencies: { 'ember-feature-flags': '2.0.1' } };
+      var depSet = { devDependencies: { 'ember-feature-flags': '2.0.1' } };
 
       var resultJSON = npmAdapter._packageJSONForDependencySet(packageJSON, depSet);
 


### PR DESCRIPTION
Useful for testing future versions, while not officially supporting them yet.