### PR TITLE
Allow chained commands and setting env vars in commands

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -20,7 +20,6 @@ bower.json
 ember-cli-build.js
 testem.js
 all-commands.sh
-test-win-commands.sh
 lint-test.js
 testem.json
 upload-coverage.sh

--- a/.travis.yml
+++ b/.travis.yml
@@ -17,7 +17,7 @@ env:
 matrix:
   fast_finish: true
   include:
-  - node_js: "4.2"
+  - node_js: "6"
     env: NPM_SCRIPT=client-test
   - node_js: "6"
     env: NPM_SCRIPT=jscs

--- a/README.md
+++ b/README.md
@@ -238,3 +238,8 @@ See an example of using `ember-try` for CI [here](https://github.com/kategengler
 ### Special Thanks
 
 - Much credit is due to [Edward Faulkner](https://github.com/ef4) The scripts in [liquid-fire](https://github.com/ef4/liquid-fire) that test against multiple ember versions were the inspiration for this project.
+
+
+### Developing
+
+- Be sure to run `npm link` and `npm link ember-try`, otherwise any `ember try` commands you run will use the version of ember-try included by ember-cli itself.

--- a/all-commands.sh
+++ b/all-commands.sh
@@ -61,12 +61,12 @@ ember try default --skip-cleanup
 # ember try test1 --config-path='test/fixtures/dummy-ember-try-config.js' --skip-cleanup true
 
 # custom command with all styles of options
-ember try default help --json
-ember try default help --json=true
-ember try default help --json true
+ember try default help --silent
+ember try default help --silent=true
+ember try default help --silent true
 
 # custom command mixed with ember try's own option
-ember try default help --json --skip-cleanup
+ember try default help --silent --skip-cleanup
 
 # try:one <scenario>
 ember try:one default
@@ -86,12 +86,12 @@ ember try:one test1 --config-path='test/fixtures/dummy-ember-try-config.js'
 ember try:one test1 --config-path='test/fixtures/dummy-ember-try-config.js' --skip-cleanup true
 
 # custom command with all styles of options
-ember try:one default --- ember help --json
-ember try:one default --- ember help --json=true
-ember try:one default --- ember help --json true
+ember try:one default --- ember help --silent
+ember try:one default --- ember help --silent=true
+ember try:one default --- ember help --silent true
 
 # custom command mixed with ember try's own option
-ember try:one default --skip-cleanup --- ember help --json
+ember try:one default --skip-cleanup --- ember help --silent
 
 
 # try:reset

--- a/all-commands.sh
+++ b/all-commands.sh
@@ -1,6 +1,9 @@
 #!/usr/bin/env bash
 set -ex
 
+npm link
+npm link ember-try
+
 # try:each
 ember try:each
 
@@ -93,3 +96,9 @@ ember try:one default --skip-cleanup --- ember help --json
 
 # try:reset
 ember try:reset
+
+FOO="5" ember try:one default --- ./fail-if-no-foo.sh
+
+ember try:one default --- FOO=5 ./fail-if-no-foo.sh
+
+ember try:one default --- 'echo 1 && echo 2'

--- a/fail-if-no-foo.sh
+++ b/fail-if-no-foo.sh
@@ -1,0 +1,5 @@
+#!/usr/bin/env bash
+
+if [[ $FOO == "" ]]; then
+  exit 1
+fi

--- a/lib/utils/run.js
+++ b/lib/utils/run.js
@@ -12,9 +12,19 @@ function run(command, args, opts) {
     opts.stdio = 'ignore';
   }
 
+  var sh = 'sh';
+  var shFlag = '-c';
+
+  if (process.platform === 'win32') {
+    sh = process.env.comspec || 'cmd';
+    shFlag = '/d /s /c';
+    opts.windowsVerbatimArguments = true;
+  }
+
   return new RSVP.Promise(function(resolve, reject) {
-    var p = spawn(command, args, opts);
-    debug('spawned: ', command, args, opts);
+    var cmdArgs = command + ' ' + args.join(' ');
+    var p = spawn(sh, [shFlag, cmdArgs], opts);
+    debug('spawned: ', sh, [shFlag, cmdArgs], opts);
     var didTimeout = false;
     if (opts.timeout) {
       setTimeout(function() {

--- a/lib/utils/run.js
+++ b/lib/utils/run.js
@@ -24,7 +24,7 @@ function run(command, args, opts) {
   return new RSVP.Promise(function(resolve, reject) {
     var cmdArgs = command + ' ' + args.join(' ');
     var p = spawn(sh, [shFlag, cmdArgs], opts);
-    debug('spawned: ', sh, [shFlag, cmdArgs], opts);
+    debug('spawned with ', sh, [shFlag, cmdArgs], opts);
     var didTimeout = false;
     if (opts.timeout) {
       setTimeout(function() {


### PR DESCRIPTION
- Add note to readme about needing to npm link ember-try

Allows:

`ember try:one <scenario> --- FOO=5 ember test`
`ember try:one <scenario> --- 'ember test && echo 2'` (note quotes)

The same goes for the command in the config file. 

Fixes #94 and #87