### PR TITLE
Minimal yarn support

### DIFF
--- a/lib/dependency-manager-adapters/npm.js
+++ b/lib/dependency-manager-adapters/npm.js
@@ -77,16 +77,22 @@ module.exports = CoreObject.extend({
     });
   },
   cleanup: function() {
-    var adapter = this;
-    return adapter._restoreOriginalDependencies().then(function() {
+    return this._restoreOriginalDependencies().then(() => {
       debug('Remove backup package.json and node_modules');
-      return RSVP.all([rimraf(path.join(adapter.cwd, adapter.packageJSONBackupFileName)),
-        rimraf(path.join(adapter.cwd, adapter.nodeModulesBackupLocation))]);
+
+      let cleanupTasks = [rimraf(path.join(this.cwd, this.packageJSONBackupFileName)),
+        rimraf(path.join(this.cwd, this.nodeModulesBackupLocation))];
+
+      if (this.yarnLockPresent) {
+        cleanupTasks.push(rimraf(path.join(this.cwd, this.yarnLockBackupFileName)));
+      }
+
+      return RSVP.all(cleanupTasks);
     }).catch(function(e) {
       console.log('Error cleaning up npm scenario:', e);
     })
-    .then(function() {
-      return adapter._install();
+    .then(() => {
+      return this._install();
     });
   },
   _findCurrentVersionOf: function(packageName) {

--- a/lib/dependency-manager-adapters/npm.js
+++ b/lib/dependency-manager-adapters/npm.js
@@ -16,8 +16,6 @@ module.exports = CoreObject.extend({
     this.adapterInit();
   },
   adapterInit: function() {
-    this.backupYarnLockPresent = fs.existsSync(path.join(this.cwd, this.yarnLockBackupFileName));
-    this.yarnLockPresent = fs.existsSync(path.join(this.cwd, this.yarnLock));
     try {
       execFileSync('yarn', [].concat(['--version']));
       this.useYarn = true;
@@ -28,9 +26,7 @@ module.exports = CoreObject.extend({
     }
   },
   useYarn: false,
-  backupYarnLockPresent: false,
   noLock: false,
-  yarnLockPresent: false,
   yarnLock: 'yarn.lock',
   yarnLockBackupFileName: 'yarn.lock.ember-try',
   configKey: 'npm',
@@ -77,13 +73,14 @@ module.exports = CoreObject.extend({
   },
   cleanup: function() {
     var adapter = this;
-    return this._restoreOriginalDependencies().then(function() {
+    var backupYarnLockPresent = fs.existsSync(path.join(this.cwd, this.yarnLockBackupFileName));
+    return this._restoreOriginalDependencies(backupYarnLockPresent).then(function() {
       debug('Remove backup package.json and node_modules');
 
       var cleanupTasks = [rimraf(path.join(adapter.cwd, adapter.packageJSONBackupFileName)),
         rimraf(path.join(adapter.cwd, adapter.nodeModulesBackupLocation))];
 
-      if (adapter.backupYarnLockPresent) {
+      if (backupYarnLockPresent) {
         cleanupTasks.push(rimraf(path.join(adapter.cwd, adapter.yarnLockBackupFileName)));
         adapter.noLock = false;
       }
@@ -147,7 +144,7 @@ module.exports = CoreObject.extend({
       }
     });
   },
-  _restoreOriginalDependencies: function() {
+  _restoreOriginalDependencies: function(backupYarnLockPresent) {
     var copy = RSVP.denodeify(fs.copy);
 
     debug('Restoring original package.json and node_modules');
@@ -159,7 +156,7 @@ module.exports = CoreObject.extend({
            path.join(this.cwd, this.nodeModules), { clobber: true })
     ];
 
-    if (this.backupYarnLockPresent) {
+    if (backupYarnLockPresent) {
       restoreTasks.push(copy(path.join(this.cwd, this.yarnLockBackupFileName),
         path.join(this.cwd, this.yarnLock)));
     }
@@ -177,10 +174,9 @@ module.exports = CoreObject.extend({
       copy(path.join(this.cwd, this.nodeModules),
            path.join(this.cwd, this.nodeModulesBackupLocation), { clobber: true })];
 
-    if (this.yarnLockPresent && this.useYarn) {
+    if (fs.existsSync(path.join(this.cwd, this.yarnLock)) && this.useYarn) {
       backupTasks.push(copy(path.join(this.cwd, this.yarnLock),
         path.join(this.cwd, this.yarnLockBackupFileName)));
-      this.backupYarnLockPresent = true;
     }
 
     return RSVP.all(backupTasks);

--- a/lib/dependency-manager-adapters/npm.js
+++ b/lib/dependency-manager-adapters/npm.js
@@ -7,13 +7,37 @@ var path = require('path');
 var extend = require('extend');
 var debug = require('debug')('ember-try:dependency-manager-adapter:npm');
 var rimraf = RSVP.denodeify(require('rimraf'));
+var execFileSync = require('child_process').execFileSync;
 
 module.exports = CoreObject.extend({
   init: function() {
     this._super.apply(this, arguments);
     this.run = this.run || require('../utils/run');
+    this.adapterInit();
   },
-  configKey: 'npm',
+  adapterInit() {
+    this.yarnLockPresent = fs.existsSync(path.join(this.cwd, this.yarnLock));
+    let yarnManagerPresent;
+    try {
+      execFileSync('yarn', [].concat(['--version']));
+      yarnManagerPresent = true;
+    } catch (e) {
+      yarnManagerPresent = false;
+    }
+    if (this.yarnLockPresent || yarnManagerPresent) {
+      this.useYarn = true;
+      this.configKey = 'yarn';
+      debug('Using yarn as dependency manager');
+    } else {
+      this.configKey = 'npm';
+      debug('Using npm as dependency manager');
+    }
+  },
+  useYarn: false,
+  yarnLockPresent: false,
+  yarnLock: 'yarn.lock',
+  yarnLockBackupFileName: 'yarn.lock.ember-try',
+  configKey: null,
   packageJSON: 'package.json',
   packageJSONBackupFileName: 'package.json.ember-try',
   nodeModules: 'node_modules',
@@ -43,7 +67,7 @@ module.exports = CoreObject.extend({
           name: dep,
           versionExpected: deps[dep],
           versionSeen: adapter._findCurrentVersionOf(dep),
-          packageManager: 'npm'
+          packageManager: this.configKey
         };
       });
 
@@ -74,14 +98,19 @@ module.exports = CoreObject.extend({
     }
   },
   _install: function() {
-    var adapter = this;
     var options = this.managerOptions || [];
 
     debug('Run npm install with options %s', options);
 
-    return adapter.run('npm', [].concat(['install'], options), { cwd: adapter.cwd }).then(function() {
-      debug('Run npm prune');
-      return adapter.run('npm', [].concat(['prune'], options), { cwd: adapter.cwd });
+    if (this.useYarn) {
+      options.push('--no-lockfile');
+    }
+
+    return this.run(this.configKey, [].concat(['install'], options), { cwd: this.cwd }).then(() => {
+      if (!this.useYarn) {
+        debug('Run npm prune');
+        return this.run(this.configKey, [].concat(['prune'], options), { cwd: this.cwd });
+      }
     });
   },
   _packageJSONForDependencySet: function(packageJSON, depSet) {
@@ -114,21 +143,36 @@ module.exports = CoreObject.extend({
 
     debug('Restoring original package.json and node_modules');
 
-    return RSVP.all([
+    let restoreTasks = [
       copy(path.join(this.cwd, this.packageJSONBackupFileName),
            path.join(this.cwd, this.packageJSON)),
       copy(path.join(this.cwd, this.nodeModulesBackupLocation),
-           path.join(this.cwd, this.nodeModules), { clobber: true })]);
+           path.join(this.cwd, this.nodeModules), { clobber: true })
+    ];
+
+    if (this.yarnLockPresent) {
+      restoreTasks.push(copy(path.join(this.cwd, this.yarnLockBackupFileName),
+        path.join(this.cwd, this.yarnLock)));
+    }
+
+    return RSVP.all(restoreTasks);
   },
   _backupOriginalDependencies: function() {
     var copy = RSVP.denodeify(fs.copy);
 
     debug('Backing up package.json and node_modules');
 
-    return RSVP.all([
+    let backupTasks = [
       copy(path.join(this.cwd, this.packageJSON),
            path.join(this.cwd, this.packageJSONBackupFileName)),
       copy(path.join(this.cwd, this.nodeModules),
-           path.join(this.cwd, this.nodeModulesBackupLocation), { clobber: true })]);
+           path.join(this.cwd, this.nodeModulesBackupLocation), { clobber: true })];
+
+    if (this.yarnLockPresent) {
+      backupTasks.push(copy(path.join(this.cwd, this.yarnLock),
+        path.join(this.cwd, this.yarnLockBackupFileName)));
+    }
+
+    return RSVP.all(backupTasks);
   }
 });

--- a/lib/dependency-manager-adapters/npm.js
+++ b/lib/dependency-manager-adapters/npm.js
@@ -15,29 +15,25 @@ module.exports = CoreObject.extend({
     this.run = this.run || require('../utils/run');
     this.adapterInit();
   },
-  adapterInit() {
+  adapterInit: function() {
+    this.backupYarnLockPresent = fs.existsSync(path.join(this.cwd, this.yarnLockBackupFileName));
     this.yarnLockPresent = fs.existsSync(path.join(this.cwd, this.yarnLock));
-    let yarnManagerPresent;
     try {
       execFileSync('yarn', [].concat(['--version']));
-      yarnManagerPresent = true;
-    } catch (e) {
-      yarnManagerPresent = false;
-    }
-    if (this.yarnLockPresent || yarnManagerPresent) {
       this.useYarn = true;
-      this.configKey = 'yarn';
       debug('Using yarn as dependency manager');
-    } else {
-      this.configKey = 'npm';
+    } catch (e) {
+      this.useYarn = false;
       debug('Using npm as dependency manager');
     }
   },
   useYarn: false,
+  backupYarnLockPresent: false,
+  noLock: false,
   yarnLockPresent: false,
   yarnLock: 'yarn.lock',
   yarnLockBackupFileName: 'yarn.lock.ember-try',
-  configKey: null,
+  configKey: 'npm',
   packageJSON: 'package.json',
   packageJSONBackupFileName: 'package.json.ember-try',
   nodeModules: 'node_modules',
@@ -60,6 +56,9 @@ module.exports = CoreObject.extend({
     debug('Write package.json with: \n', JSON.stringify(newPackageJSON));
 
     fs.writeFileSync(packageJSONFile, JSON.stringify(newPackageJSON, null, 2));
+    if (this.useYarn) {
+      this.noLock = true;
+    }
     return adapter._install().then(function() {
       var deps = extend({}, depSet.dependencies || {}, depSet.devDependencies || {});
       var currentDeps = Object.keys(deps).map(function(dep) {
@@ -67,7 +66,7 @@ module.exports = CoreObject.extend({
           name: dep,
           versionExpected: deps[dep],
           versionSeen: adapter._findCurrentVersionOf(dep),
-          packageManager: adapter.configKey
+          packageManager: adapter.useYarn ? 'yarn' : 'npm'
         };
       });
 
@@ -77,22 +76,24 @@ module.exports = CoreObject.extend({
     });
   },
   cleanup: function() {
-    return this._restoreOriginalDependencies().then(() => {
+    var adapter = this;
+    return this._restoreOriginalDependencies().then(function() {
       debug('Remove backup package.json and node_modules');
 
-      let cleanupTasks = [rimraf(path.join(this.cwd, this.packageJSONBackupFileName)),
-        rimraf(path.join(this.cwd, this.nodeModulesBackupLocation))];
+      var cleanupTasks = [rimraf(path.join(adapter.cwd, adapter.packageJSONBackupFileName)),
+        rimraf(path.join(adapter.cwd, adapter.nodeModulesBackupLocation))];
 
-      if (this.yarnLockPresent) {
-        cleanupTasks.push(rimraf(path.join(this.cwd, this.yarnLockBackupFileName)));
+      if (adapter.backupYarnLockPresent) {
+        cleanupTasks.push(rimraf(path.join(adapter.cwd, adapter.yarnLockBackupFileName)));
+        adapter.noLock = false;
       }
 
       return RSVP.all(cleanupTasks);
     }).catch(function(e) {
       console.log('Error cleaning up npm scenario:', e);
     })
-    .then(() => {
-      return this._install();
+    .then(function() {
+      return adapter._install();
     });
   },
   _findCurrentVersionOf: function(packageName) {
@@ -104,18 +105,20 @@ module.exports = CoreObject.extend({
     }
   },
   _install: function() {
+    var adapter = this;
     var options = this.managerOptions || [];
 
     debug('Run npm install with options %s', options);
 
-    if (this.useYarn) {
-      options.push('--no-lockfile');
+    var cmd = this.useYarn ? 'yarn' : 'npm';
+    if (this.useYarn && this.noLock && options.indexOf('--no-lockfile') === -1) {
+      options = options.concat(['--no-lockfile']);
     }
 
-    return this.run(this.configKey, [].concat(['install'], options), { cwd: this.cwd }).then(() => {
-      if (!this.useYarn) {
+    return this.run(cmd, [].concat(['install'], options), { cwd: this.cwd }).then(function() {
+      if (!adapter.useYarn) {
         debug('Run npm prune');
-        return this.run(this.configKey, [].concat(['prune'], options), { cwd: this.cwd });
+        return adapter.run(adapter.configKey, [].concat(['prune'], options), { cwd: adapter.cwd });
       }
     });
   },
@@ -149,14 +152,14 @@ module.exports = CoreObject.extend({
 
     debug('Restoring original package.json and node_modules');
 
-    let restoreTasks = [
+    var restoreTasks = [
       copy(path.join(this.cwd, this.packageJSONBackupFileName),
            path.join(this.cwd, this.packageJSON)),
       copy(path.join(this.cwd, this.nodeModulesBackupLocation),
            path.join(this.cwd, this.nodeModules), { clobber: true })
     ];
 
-    if (this.yarnLockPresent) {
+    if (this.backupYarnLockPresent) {
       restoreTasks.push(copy(path.join(this.cwd, this.yarnLockBackupFileName),
         path.join(this.cwd, this.yarnLock)));
     }
@@ -168,15 +171,16 @@ module.exports = CoreObject.extend({
 
     debug('Backing up package.json and node_modules');
 
-    let backupTasks = [
+    var backupTasks = [
       copy(path.join(this.cwd, this.packageJSON),
            path.join(this.cwd, this.packageJSONBackupFileName)),
       copy(path.join(this.cwd, this.nodeModules),
            path.join(this.cwd, this.nodeModulesBackupLocation), { clobber: true })];
 
-    if (this.yarnLockPresent) {
+    if (this.yarnLockPresent && this.useYarn) {
       backupTasks.push(copy(path.join(this.cwd, this.yarnLock),
         path.join(this.cwd, this.yarnLockBackupFileName)));
+      this.backupYarnLockPresent = true;
     }
 
     return RSVP.all(backupTasks);

--- a/lib/dependency-manager-adapters/npm.js
+++ b/lib/dependency-manager-adapters/npm.js
@@ -67,7 +67,7 @@ module.exports = CoreObject.extend({
           name: dep,
           versionExpected: deps[dep],
           versionSeen: adapter._findCurrentVersionOf(dep),
-          packageManager: this.configKey
+          packageManager: adapter.configKey
         };
       });
 

--- a/lib/dependency-manager-adapters/npm.js
+++ b/lib/dependency-manager-adapters/npm.js
@@ -26,7 +26,6 @@ module.exports = CoreObject.extend({
     }
   },
   useYarn: false,
-  noLock: false,
   yarnLock: 'yarn.lock',
   yarnLockBackupFileName: 'yarn.lock.ember-try',
   configKey: 'npm',
@@ -52,10 +51,7 @@ module.exports = CoreObject.extend({
     debug('Write package.json with: \n', JSON.stringify(newPackageJSON));
 
     fs.writeFileSync(packageJSONFile, JSON.stringify(newPackageJSON, null, 2));
-    if (this.useYarn) {
-      this.noLock = true;
-    }
-    return adapter._install().then(function() {
+    return adapter._install(this.useYarn).then(function() {
       var deps = extend({}, depSet.dependencies || {}, depSet.devDependencies || {});
       var currentDeps = Object.keys(deps).map(function(dep) {
         return {
@@ -82,7 +78,6 @@ module.exports = CoreObject.extend({
 
       if (backupYarnLockPresent) {
         cleanupTasks.push(rimraf(path.join(adapter.cwd, adapter.yarnLockBackupFileName)));
-        adapter.noLock = false;
       }
 
       return RSVP.all(cleanupTasks);
@@ -90,7 +85,7 @@ module.exports = CoreObject.extend({
       console.log('Error cleaning up npm scenario:', e);
     })
     .then(function() {
-      return adapter._install();
+      return adapter._install(false);
     });
   },
   _findCurrentVersionOf: function(packageName) {
@@ -101,14 +96,14 @@ module.exports = CoreObject.extend({
       return null;
     }
   },
-  _install: function() {
+  _install: function(noLock) {
     var adapter = this;
     var options = this.managerOptions || [];
 
     debug('Run npm install with options %s', options);
 
     var cmd = this.useYarn ? 'yarn' : 'npm';
-    if (this.useYarn && this.noLock && options.indexOf('--no-lockfile') === -1) {
+    if (this.useYarn && noLock && options.indexOf('--no-lockfile') === -1) {
       options = options.concat(['--no-lockfile']);
     }
 

--- a/test/dependency-manager-adapters/npm-adapter-test.js
+++ b/test/dependency-manager-adapters/npm-adapter-test.js
@@ -61,7 +61,13 @@ describe('npmAdapter', function() {
         }
       }], { allowPassthrough: false });
 
-      return new NpmAdapter({ cwd: tmpdir, run: stubbedRun })._install().then(function() {
+      return new NpmAdapter({
+        cwd: tmpdir,
+        run: stubbedRun,
+        adapterInit() {
+          this.configKey = 'npm';
+        }
+      })._install().then(function() {
         expect(runCount).to.equal(2, 'Both commands should run');
       }).catch(function(err) {
         console.log(err);
@@ -86,7 +92,14 @@ describe('npmAdapter', function() {
         }
       }], { allowPassthrough: false });
 
-      return new NpmAdapter({ cwd: tmpdir, run: stubbedRun, managerOptions: ['--no-shrinkwrap=true'] })._install().then(function() {
+      return new NpmAdapter({
+        cwd: tmpdir,
+        run: stubbedRun,
+        managerOptions: ['--no-shrinkwrap=true'],
+        adapterInit() {
+          this.configKey = 'npm';
+        }
+      })._install().then(function() {
         expect(runCount).to.equal(2, 'Both commands should run');
       }).catch(function(err) {
         console.log(err);

--- a/test/utils/dependency-manager-adapter-factory-test.js
+++ b/test/utils/dependency-manager-adapter-factory-test.js
@@ -5,9 +5,10 @@ var DependencyManagerAdapterFactory = require('../../lib/utils/dependency-manage
 
 describe('DependencyManagerAdapterFactory', function() {
   describe('generateFromConfig', function() {
-    it('creates npm adapter when config has npm key', function() {
-      var adapters = DependencyManagerAdapterFactory.generateFromConfig({ scenarios: [{ npm: {} }] }, 'here');
-      expect(adapters[0].configKey).to.equal('npm');
+    it('creates npm or yarn adapter when config has npm key', function() {
+      let configKeys = ['npm', 'yarn'];
+      let adapters = DependencyManagerAdapterFactory.generateFromConfig({ scenarios: [{ npm: {} }] }, 'here');
+      expect(configKeys).to.include(adapters[0].configKey);
       expect(adapters.length).to.equal(1);
     });
 
@@ -18,8 +19,9 @@ describe('DependencyManagerAdapterFactory', function() {
     });
 
     it('creates both adapters when it has both keys', function() {
-      var adapters = DependencyManagerAdapterFactory.generateFromConfig({ scenarios: [{ bower: {}, npm: {} }] }, 'here');
-      expect(adapters[0].configKey).to.equal('npm');
+      let configKeys = ['npm', 'yarn'];
+      let adapters = DependencyManagerAdapterFactory.generateFromConfig({ scenarios: [{ bower: {}, npm: {} }] }, 'here');
+      expect(configKeys).to.include(adapters[0].configKey);
       expect(adapters[1].configKey).to.equal('bower');
       expect(adapters.length).to.equal(2);
     });

--- a/test/utils/dependency-manager-adapter-factory-test.js
+++ b/test/utils/dependency-manager-adapter-factory-test.js
@@ -5,10 +5,9 @@ var DependencyManagerAdapterFactory = require('../../lib/utils/dependency-manage
 
 describe('DependencyManagerAdapterFactory', function() {
   describe('generateFromConfig', function() {
-    it('creates npm or yarn adapter when config has npm key', function() {
-      let configKeys = ['npm', 'yarn'];
-      let adapters = DependencyManagerAdapterFactory.generateFromConfig({ scenarios: [{ npm: {} }] }, 'here');
-      expect(configKeys).to.include(adapters[0].configKey);
+    it('creates npm adapter when config has npm key', function() {
+      var adapters = DependencyManagerAdapterFactory.generateFromConfig({ scenarios: [{ npm: {} }] }, 'here');
+      expect(adapters[0].configKey).to.equal('npm');
       expect(adapters.length).to.equal(1);
     });
 
@@ -19,9 +18,8 @@ describe('DependencyManagerAdapterFactory', function() {
     });
 
     it('creates both adapters when it has both keys', function() {
-      let configKeys = ['npm', 'yarn'];
-      let adapters = DependencyManagerAdapterFactory.generateFromConfig({ scenarios: [{ bower: {}, npm: {} }] }, 'here');
-      expect(configKeys).to.include(adapters[0].configKey);
+      var adapters = DependencyManagerAdapterFactory.generateFromConfig({ scenarios: [{ bower: {}, npm: {} }] }, 'here');
+      expect(adapters[0].configKey).to.equal('npm');
       expect(adapters[1].configKey).to.equal('bower');
       expect(adapters.length).to.equal(2);
     });


### PR DESCRIPTION
- use `yarn` package manager instead of npm if `yarn.lock` is present or `yarn --version` command returns anything other than error.
- if `yarn.lock` is present on the project it gets backed up / restored / cleaned up. 