### PR TITLE
fix CI client-test cache problem

### DIFF
--- a/all-commands.sh
+++ b/all-commands.sh
@@ -1,6 +1,10 @@
 #!/usr/bin/env bash
 set -ex
 
+# cleanup to avoid nested folders accumulation due to node_modules
+# folder being cached in CI
+rm -rf node_modules/ember-try
+
 npm link
 npm link ember-try
 


### PR DESCRIPTION
Remove `node_modules/ember-try` on each travis.ci run to avoid accumulation of nested folders because of caching of `node_modules` folder and repeated `npm link` / `npm link ember-try` commands being executed on each `client-test` travis scenario run.

Accumulation example can be observed here: https://travis-ci.org/ember-cli/ember-try/jobs/206107877