### PR TITLE
Require ResultSummary before any npm scenarios run

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -20,5 +20,6 @@ bower.json
 ember-cli-build.js
 testem.js
 all-commands.sh
+smoke-test.sh
 testem.json
 upload-coverage.sh

--- a/.travis.yml
+++ b/.travis.yml
@@ -7,12 +7,8 @@ node_js:
 
 sudo: false
 
-cache:
-  directories:
-    - node_modules
-
 env:
-  - NPM_SCRIPT=all-test
+  - NPM_SCRIPT=node-test
 
 matrix:
   fast_finish: true
@@ -23,6 +19,10 @@ matrix:
     env: NPM_SCRIPT=lint
   - node_js: "6"
     env: NPM_SCRIPT=node-test-with-coverage
+  - node_js: "4"
+    env: NPM_SCRIPT=smoke-test
+  - node_js: "6"
+    env: NPM_SCRIPT=smoke-test
 
 before_install:
   - curl -o- -L https://yarnpkg.com/install.sh | bash

--- a/.travis.yml
+++ b/.travis.yml
@@ -12,7 +12,7 @@ cache:
     - node_modules
 
 env:
-  - NPM_SCRIPT=node-test
+  - NPM_SCRIPT=all-test
 
 matrix:
   fast_finish: true
@@ -25,6 +25,9 @@ matrix:
     env: NPM_SCRIPT=node-test-with-coverage
 
 before_install:
+  - curl -o- -L https://yarnpkg.com/install.sh | bash
+  - export PATH=$HOME/.yarn/bin:$PATH
+  - yarn --version
   - npm config set spin false
   - npm install -g bower
   - bower --version

--- a/lib/dependency-manager-adapters/npm.js
+++ b/lib/dependency-manager-adapters/npm.js
@@ -68,10 +68,6 @@ module.exports = CoreObject.extend({
       return RSVP.all(cleanupTasks);
     }).catch(function(e) {
       console.log('Error cleaning up npm scenario:', e);
-    })
-    .then(function() {
-      var yarnLockPresent = fs.existsSync(path.join(adapter.cwd, adapter.yarnLock));
-      return adapter._install({ useYarnLock: yarnLockPresent });
     });
   },
   _setYarnAvailability: function() {
@@ -95,15 +91,14 @@ module.exports = CoreObject.extend({
       return null;
     }
   },
-  _install: function(options) {
+  _install: function() {
     var adapter = this;
-    var opts = extend({ useYarnLock: false }, options);
     var mgrOptions = this.managerOptions || [];
 
     debug('Run npm install with options %s', mgrOptions);
 
     var cmd = this.useYarnCommand ? 'yarn' : 'npm';
-    if (this.useYarnCommand && !opts.useYarnLock && mgrOptions.indexOf('--no-lockfile') === -1) {
+    if (this.useYarnCommand && mgrOptions.indexOf('--no-lockfile') === -1) {
       mgrOptions = mgrOptions.concat(['--no-lockfile']);
     }
 

--- a/lib/tasks/try-each.js
+++ b/lib/tasks/try-each.js
@@ -11,6 +11,7 @@ module.exports = CoreObject.extend({
     // Required lazily to improve startup speed.
     var ScenarioManager = require('./../utils/scenario-manager');
     var DependencyManagerAdapterFactory = require('./../utils/dependency-manager-adapter-factory');
+    this.ResultSummary = require('./../utils/result-summary');
 
     var task = this;
     var dependencyManagerAdapters = task.dependencyManagerAdapters || DependencyManagerAdapterFactory.generateFromConfig(task.config, task.project.root);
@@ -120,10 +121,7 @@ module.exports = CoreObject.extend({
   },
 
   _printResults: function(results) {
-    // Required lazily to improve startup speed.
-    var ResultSummary = require('./../utils/result-summary');
-
-    new ResultSummary({ ui: this.ui, results: results }).print();
+    new this.ResultSummary({ ui: this.ui, results: results }).print();
   },
 
   _exitAsAppropriate: function(results) {

--- a/package.json
+++ b/package.json
@@ -11,7 +11,9 @@
     "start": "ember server",
     "client-test": "./all-commands.sh",
     "node-test": "mocha test/**/*.js",
+    "all-test": "npm run-script node-test && npm run-script smoke-test",
     "node-test-with-coverage": "istanbul cover _mocha test/**/*.js && ./upload-coverage.sh",
+    "smoke-test": "./smoke-test.sh",
     "lint": "eslint lib test",
     "test": "npm run-script lint && npm run-script node-test && npm run-script client-test"
   },

--- a/smoke-test.sh
+++ b/smoke-test.sh
@@ -1,0 +1,12 @@
+#!/usr/bin/env bash
+set -ex
+
+# cleanup to avoid nested folders accumulation due to node_modules
+# folder being cached in CI
+rm -rf node_modules/ember-try
+
+npm link
+npm link ember-try
+
+# try:each
+ember try:each --config-path='test/fixtures/dummy-ember-try-config-with-npm-scenarios.js'

--- a/smoke-test.sh
+++ b/smoke-test.sh
@@ -8,5 +8,4 @@ rm -rf node_modules/ember-try
 npm link
 npm link ember-try
 
-# try:each
-ember try:each --config-path='test/fixtures/dummy-ember-try-config-with-npm-scenarios.js'
+ember try:one test2 --config-path='test/fixtures/dummy-ember-try-config-with-npm-scenarios.js'

--- a/test/dependency-manager-adapters/npm-adapter-test.js
+++ b/test/dependency-manager-adapters/npm-adapter-test.js
@@ -152,27 +152,7 @@ describe('npmAdapter', function() {
           _runYarnCheck: passedYarnCheck,
           managerOptions: ['--flat']
         })._install().then(function() {
-          expect(runCount).to.equal(1, 'Only yarn install should run with manager options and --no-lockfile');
-        });
-      });
-
-      it('runs yarn install with lockfile if given option', function() {
-        writeJSONFile('package.json', fixturePackage);
-        var runCount = 0;
-        var stubbedRun = generateMockRun([{
-          command: 'yarn install',
-          callback: function() {
-            runCount++;
-            return RSVP.resolve();
-          }
-        }], { allowPassthrough: false });
-
-        return new NpmAdapter({
-          cwd: tmpdir,
-          run: stubbedRun,
-          _runYarnCheck: passedYarnCheck
-        })._install({ useYarnLock: true }).then(function() {
-          expect(runCount).to.equal(1, 'Only yarn install should run without --no-lockfile');
+          expect(runCount).to.equal(1, 'Only yarn install should run with manager options');
         });
       });
     });
@@ -259,26 +239,6 @@ describe('npmAdapter', function() {
       npmAdapter._setYarnAvailability();
 
       expect(npmAdapter.useYarnCommand).to.equal(false);
-    });
-  });
-
-  describe('#cleanup', function() {
-    it('runs _install using yarn lock if present', function() {
-      fs.writeFileSync('yarn.lock', 'stuff');
-      var installOptions = {};
-      function mockInstall(options) {
-        installOptions = options;
-      }
-
-      return new NpmAdapter({
-        cwd: tmpdir,
-        _restoreOriginalDependencies: function() {
-          return RSVP.resolve();
-        },
-        _install: mockInstall
-      }).cleanup().then(function() {
-        expect(installOptions).to.eql({ useYarnLock: true });
-      });
     });
   });
 });

--- a/test/fixtures/dummy-ember-try-config-with-npm-scenarios.js
+++ b/test/fixtures/dummy-ember-try-config-with-npm-scenarios.js
@@ -1,0 +1,20 @@
+module.exports = {
+  scenarios: [
+    {
+      name: 'test1',
+      bower: {
+        dependencies: {
+          ember: '1.10.0'
+        }
+      }
+    },
+    {
+      name: 'test2',
+      npm: {
+        dependencies: {
+          'ember-feature-flags': '3.0.0'
+        }
+      }
+    }
+  ]
+};

--- a/test/fixtures/dummy-ember-try-config-with-npm-scenarios.js
+++ b/test/fixtures/dummy-ember-try-config-with-npm-scenarios.js
@@ -10,6 +10,7 @@ module.exports = {
     },
     {
       name: 'test2',
+      command: 'ember test',
       npm: {
         dependencies: {
           'ember-feature-flags': '3.0.0'


### PR DESCRIPTION
- Also remove unnecessary install step


Managed to expose the bug with `smoke-test.sh` but cannot get it to pass because CI is using the ember-try included with ember-cli, rather than the one in the repo. This problem was not exposed with `all-commands.sh` because it did not include any npm scenarios.

Fixes #121 