### PR TITLE
Updating dependency manager debug statements to output runtime options

### DIFF
--- a/lib/dependency-manager-adapters/bower.js
+++ b/lib/dependency-manager-adapters/bower.js
@@ -110,6 +110,10 @@ module.exports = CoreObject.extend({
     var adapter = this;
     var options = this.managerOptions || [];
 
+    if (options.indexOf('--config.interactive=false') === -1) {
+      options = options.concat(['--config.interactive=false']);
+    }
+
     return rimraf(path.join(adapter.cwd, 'bower_components'))
       .then(function() {
         debug('Remove bower_components');
@@ -117,7 +121,8 @@ module.exports = CoreObject.extend({
       })
       .then(function(bowerPath) {
         debug('Run bower install using bower at %s', bowerPath);
-        return adapter.run('node', [].concat([bowerPath, 'install', '--config.interactive=false'], options), { cwd: adapter.cwd });
+        debug('Run bower install with options %s', options);
+        return adapter.run('node', [].concat([bowerPath, 'install'], options), { cwd: adapter.cwd });
       });
   },
   _bowerJSONForDependencySet: function(bowerJSON, depSet) {

--- a/lib/dependency-manager-adapters/npm.js
+++ b/lib/dependency-manager-adapters/npm.js
@@ -95,12 +95,12 @@ module.exports = CoreObject.extend({
     var adapter = this;
     var mgrOptions = this.managerOptions || [];
 
-    debug('Run npm install with options %s', mgrOptions);
-
     var cmd = this.useYarnCommand ? 'yarn' : 'npm';
     if (this.useYarnCommand && mgrOptions.indexOf('--no-lockfile') === -1) {
       mgrOptions = mgrOptions.concat(['--no-lockfile']);
     }
+
+    debug('Run ' + cmd + ' install with options %s', mgrOptions);
 
     return this.run(cmd, [].concat(['install'], mgrOptions), { cwd: this.cwd }).then(function() {
       if (!adapter.useYarnCommand) {

--- a/test/dependency-manager-adapters/bower-adapter-test.js
+++ b/test/dependency-manager-adapters/bower-adapter-test.js
@@ -127,9 +127,9 @@ describe('bowerAdapter', function() {
         expect(command).to.equal('node');
         expect(args[0]).to.match(/bower/);
         expect(args[1]).to.equal('install');
-        expect(args[2]).to.equal('--config.interactive=false');
-        expect(args[3]).to.equal('--verbose=true');
-        expect(args[4]).to.equal('--allow-root=true');
+        expect(args[2]).to.equal('--verbose=true');
+        expect(args[3]).to.equal('--allow-root=true');
+        expect(args[4]).to.equal('--config.interactive=false');
         return RSVP.resolve();
       };
       return new BowerAdapter({ cwd: tmpdir, run: stubbedRun, managerOptions: ['--verbose=true', '--allow-root=true'] })._install();


### PR DESCRIPTION
Noticed that the debug statements within the dependency managers weren't outputting the default options.