### PR TITLE
Change Yarn detection to look for lockfile

### DIFF
--- a/README.md
+++ b/README.md
@@ -235,7 +235,7 @@ If no `config/ember-try.js` file is present, the default config will be used. Th
 
 ##### A note on npm scenarios / "What about yarn?"
 
-If `yarn` is available globally on the system the `ember-try` command is run on, all npm scenarios will use `yarn` for install with the `--no-lockfile` option. 
+If you include `useYarn: true` in your `ember-try` config, all npm scenarios will use `yarn` for install with the `--no-lockfile` option.
 If the project has a `yarn.lock`, it will be used *only* on cleanup to restore the project to a clean state. 
  
 ###### But I use yarn, why `--no-lockfile`?

--- a/lib/dependency-manager-adapters/npm.js
+++ b/lib/dependency-manager-adapters/npm.js
@@ -22,6 +22,9 @@ module.exports = CoreObject.extend({
   nodeModules: 'node_modules',
   nodeModulesBackupLocation: '.node_modules.ember-try',
   setup: function(options) {
+    if (!options) {
+      options = {};
+    }
     this._runYarnCheck(options.ui);
     return this._backupOriginalDependencies();
   },

--- a/lib/dependency-manager-adapters/npm.js
+++ b/lib/dependency-manager-adapters/npm.js
@@ -7,6 +7,7 @@ var path = require('path');
 var extend = require('extend');
 var debug = require('debug')('ember-try:dependency-manager-adapter:npm');
 var rimraf = RSVP.denodeify(require('rimraf'));
+var chalk = require('chalk');
 
 module.exports = CoreObject.extend({
   init: function() {
@@ -73,7 +74,7 @@ module.exports = CoreObject.extend({
     if (!this.useYarnCommand) {
       try {
         if (fs.statSync(path.join(this.cwd, this.yarnLock)).isFile()) {
-          ui.writeLine('Detected a yarn.lock file, add useYarn: true to your configuration if you want to use Yarn to install npm dependencies.');
+          ui.writeLine(chalk.yellow('Detected a yarn.lock file, add useYarn: true to your configuration if you want to use Yarn to install npm dependencies.'));
         }
       } catch (e) {
         // If no yarn.lock is found, no need to warn.

--- a/lib/dependency-manager-adapters/npm.js
+++ b/lib/dependency-manager-adapters/npm.js
@@ -12,7 +12,6 @@ module.exports = CoreObject.extend({
   init: function() {
     this._super.apply(this, arguments);
     this.run = this.run || require('../utils/run');
-    this._runYarnCheck();
   },
   useYarnCommand: false,
   yarnLock: 'yarn.lock',
@@ -21,7 +20,8 @@ module.exports = CoreObject.extend({
   packageJSONBackupFileName: 'package.json.ember-try',
   nodeModules: 'node_modules',
   nodeModulesBackupLocation: '.node_modules.ember-try',
-  setup: function() {
+  setup: function({ ui }) {
+    this._runYarnCheck(ui);
     return this._backupOriginalDependencies();
   },
   changeToDependencySet: function(depSet) {
@@ -69,11 +69,11 @@ module.exports = CoreObject.extend({
       console.log('Error cleaning up npm scenario:', e);
     });
   },
-  _runYarnCheck: function() {
+  _runYarnCheck: function(ui) {
     if (!this.useYarnCommand) {
       try {
         if (fs.statSync(path.join(this.cwd, this.yarnLock)).isFile()) {
-          console.log('Detected a yarn.lock file, add useYarn: true to your configuration if you want to use Yarn to install npm dependencies.');
+          ui.writeLine('Detected a yarn.lock file, add useYarn: true to your configuration if you want to use Yarn to install npm dependencies.');
         }
       } catch (e) {
         // If no yarn.lock is found, no need to warn.

--- a/lib/dependency-manager-adapters/npm.js
+++ b/lib/dependency-manager-adapters/npm.js
@@ -21,8 +21,8 @@ module.exports = CoreObject.extend({
   packageJSONBackupFileName: 'package.json.ember-try',
   nodeModules: 'node_modules',
   nodeModulesBackupLocation: '.node_modules.ember-try',
-  setup: function({ ui }) {
-    this._runYarnCheck(ui);
+  setup: function(options) {
+    this._runYarnCheck(options.ui);
     return this._backupOriginalDependencies();
   },
   changeToDependencySet: function(depSet) {

--- a/lib/dependency-manager-adapters/npm.js
+++ b/lib/dependency-manager-adapters/npm.js
@@ -7,13 +7,12 @@ var path = require('path');
 var extend = require('extend');
 var debug = require('debug')('ember-try:dependency-manager-adapter:npm');
 var rimraf = RSVP.denodeify(require('rimraf'));
-var execFileSync = require('child_process').execFileSync;
 
 module.exports = CoreObject.extend({
   init: function() {
     this._super.apply(this, arguments);
     this.run = this.run || require('../utils/run');
-    this._setYarnAvailability();
+    this._runYarnCheck();
   },
   useYarnCommand: false,
   yarnLock: 'yarn.lock',
@@ -70,18 +69,16 @@ module.exports = CoreObject.extend({
       console.log('Error cleaning up npm scenario:', e);
     });
   },
-  _setYarnAvailability: function() {
-    try {
-      this._runYarnCheck();
-      this.useYarnCommand = true;
-      debug('Using yarn as dependency manager');
-    } catch (e) {
-      this.useYarnCommand = false;
-      debug('Using npm as dependency manager');
-    }
-  },
   _runYarnCheck: function() {
-    execFileSync('yarn', [].concat(['--version']));
+    if (!this.useYarnCommand) {
+      try {
+        if (fs.statSync(path.join(this.cwd, this.yarnLock)).isFile()) {
+          console.log('Detected a yarn.lock file, add useYarn: true to your configuration if you want to use Yarn to install npm dependencies.');
+        }
+      } catch (e) {
+        // If no yarn.lock is found, no need to warn.
+      }
+    }
   },
   _findCurrentVersionOf: function(packageName) {
     var filename = path.join(this.cwd, this.nodeModules, packageName, this.packageJSON);

--- a/lib/utils/dependency-manager-adapter-factory.js
+++ b/lib/utils/dependency-manager-adapter-factory.js
@@ -21,7 +21,7 @@ module.exports = {
       }
     });
     if (hasNpm) {
-      adapters.push(new NpmAdapter({ cwd: root, managerOptions: config.npmOptions }));
+      adapters.push(new NpmAdapter({ cwd: root, managerOptions: config.npmOptions, useYarnCommand: config.useYarn }));
     }
     if (hasBower) {
       adapters.push(new BowerAdapter({ cwd: root, managerOptions: config.bowerOptions }));

--- a/lib/utils/scenario-manager.js
+++ b/lib/utils/scenario-manager.js
@@ -20,7 +20,7 @@ module.exports = CoreObject.extend({
     var ui = this.ui;
 
     return mapSeries(this.dependencyManagerAdapters, function(depManager) {
-      return depManager.setup({ ui });
+      return depManager.setup({ ui: ui });
     });
   },
 

--- a/lib/utils/scenario-manager.js
+++ b/lib/utils/scenario-manager.js
@@ -17,8 +17,10 @@ module.exports = CoreObject.extend({
   },
 
   setup: function() {
+    var ui = this.ui;
+
     return mapSeries(this.dependencyManagerAdapters, function(depManager) {
-      return depManager.setup();
+      return depManager.setup({ ui });
     });
   },
 

--- a/test/dependency-manager-adapters/npm-adapter-test.js
+++ b/test/dependency-manager-adapters/npm-adapter-test.js
@@ -215,32 +215,6 @@ describe('npmAdapter', function() {
       expect(resultJSON.devDependencies).to.not.have.property('ember-feature-flags');
     });
   });
-
-  describe('#_setYarnAvailability', function() {
-    it('sets useYarnCommand to true if yarn check does not raise', function() {
-      var npmAdapter = new NpmAdapter({
-        cwd: tmpdir,
-        _runYarnCheck: function() {}
-      });
-
-      npmAdapter._setYarnAvailability();
-
-      expect(npmAdapter.useYarnCommand).to.equal(true);
-    });
-
-    it('sets useYarnCommand to false if yarn check raises', function() {
-      var npmAdapter = new NpmAdapter({
-        cwd: tmpdir,
-        _runYarnCheck: function() {
-          throw new Error();
-        }
-      });
-
-      npmAdapter._setYarnAvailability();
-
-      expect(npmAdapter.useYarnCommand).to.equal(false);
-    });
-  });
 });
 
 function assertFileContainsJSON(filename, expectedObj) {

--- a/test/dependency-manager-adapters/npm-adapter-test.js
+++ b/test/dependency-manager-adapters/npm-adapter-test.js
@@ -15,12 +15,6 @@ var root = process.cwd();
 var tmproot = path.join(root, 'tmp');
 var tmpdir;
 
-var failedYarnCheck = function() {
-  throw new Error('Yarn not available');
-};
-
-var passedYarnCheck = function() {};
-
 describe('npmAdapter', function() {
   beforeEach(function() {
     tmpdir = tmp.in(tmproot);
@@ -38,8 +32,7 @@ describe('npmAdapter', function() {
       writeJSONFile('node_modules/prove-it.json', { originalNodeModules: true });
       writeJSONFile('package.json', { originalPackageJSON: true });
       return new NpmAdapter({
-        cwd: tmpdir,
-        _runYarnCheck: failedYarnCheck
+        cwd: tmpdir
       }).setup().then(function() {
         assertFileContainsJSON('package.json.ember-try', { originalPackageJSON: true });
         assertFileContainsJSON('.node_modules.ember-try/prove-it.json', { originalNodeModules: true });
@@ -73,8 +66,7 @@ describe('npmAdapter', function() {
 
         return new NpmAdapter({
           cwd: tmpdir,
-          run: stubbedRun,
-          _runYarnCheck: failedYarnCheck
+          run: stubbedRun
         })._install().then(function() {
           expect(runCount).to.equal(2, 'Both commands should run');
         }).catch(function(err) {
@@ -103,7 +95,6 @@ describe('npmAdapter', function() {
         return new NpmAdapter({
           cwd: tmpdir,
           run: stubbedRun,
-          _runYarnCheck: failedYarnCheck,
           managerOptions: ['--no-shrinkwrap=true']
         })._install().then(function() {
           expect(runCount).to.equal(2, 'Both commands should run');
@@ -129,7 +120,7 @@ describe('npmAdapter', function() {
         return new NpmAdapter({
           cwd: tmpdir,
           run: stubbedRun,
-          _runYarnCheck: passedYarnCheck
+          useYarnCommand: true
         })._install().then(function() {
           expect(runCount).to.equal(1, 'Only yarn install should run');
         });
@@ -149,7 +140,7 @@ describe('npmAdapter', function() {
         return new NpmAdapter({
           cwd: tmpdir,
           run: stubbedRun,
-          _runYarnCheck: passedYarnCheck,
+          useYarnCommand: true,
           managerOptions: ['--flat']
         })._install().then(function() {
           expect(runCount).to.equal(1, 'Only yarn install should run with manager options');

--- a/test/fixtures/dummy-ember-try-config-with-npm-scenarios.js
+++ b/test/fixtures/dummy-ember-try-config-with-npm-scenarios.js
@@ -1,4 +1,5 @@
 module.exports = {
+  useYarn: true,
   scenarios: [
     {
       name: 'test1',

--- a/test/tasks/try-each-test.js
+++ b/test/tasks/try-each-test.js
@@ -264,10 +264,12 @@ describe('tryEach', function() {
       });
 
       writeJSONFile('package.json', fixturePackage);
+      fs.closeSync(fs.openSync('yarn.lock', 'w'));
       fs.mkdirSync('node_modules');
       writeJSONFile('bower.json', fixtureBower);
       return tryEachTask.run(config.scenarios, {}).then(function(exitCode) {
         expect(exitCode).to.equal(0, 'exits 0 when all scenarios succeed');
+        expect(output).to.include('Detected a yarn.lock file, add useYarn: true to your configuration if you want to use Yarn to install npm dependencies.');
         expect(output).to.include('Scenario first: SUCCESS');
         expect(output).to.include('Scenario second: SUCCESS');
         expect(output).to.include('Scenario with-bower-resolutions: SUCCESS');

--- a/test/tasks/try-each-test.js
+++ b/test/tasks/try-each-test.js
@@ -264,7 +264,7 @@ describe('tryEach', function() {
       });
 
       writeJSONFile('package.json', fixturePackage);
-      fs.writeFileSync('yarn.lock', 'w');
+      fs.writeFileSync('yarn.lock', '');
       fs.mkdirSync('node_modules');
       writeJSONFile('bower.json', fixtureBower);
       return tryEachTask.run(config.scenarios, {}).then(function(exitCode) {

--- a/test/tasks/try-each-test.js
+++ b/test/tasks/try-each-test.js
@@ -264,7 +264,7 @@ describe('tryEach', function() {
       });
 
       writeJSONFile('package.json', fixturePackage);
-      fs.closeSync(fs.openSync('yarn.lock', 'w'));
+      fs.writeFileSync('yarn.lock', 'w');
       fs.mkdirSync('node_modules');
       writeJSONFile('bower.json', fixtureBower);
       return tryEachTask.run(config.scenarios, {}).then(function(exitCode) {


### PR DESCRIPTION
This is a naïve fix for #133. It would seemingly work to merge, but I’m not sure if more nuance is needed, or whether the change should extend further.

1. I made use of `throw` because it was the minimal change, since that’s what `execFileSync` would do when `yarn --version` failed. I could instead strip out the exception handling and directly use the simple boolean check of `isFile()`.

2. The existing test for this doesn’t really exercise things fully, it mocks `_runYarnCheck`. Would it be worth using a true `yarn.lock` for testing?

3. What happens if a `yarn.lock` is detected but `yarn` itself isn’t present? Should the `execFileSync` perhaps remain? 🤔

Let me know your thoughts and I’m happy to improve this. Thanks for `ember-try`, it’s endlessly useful!