### PR TITLE
Put quotes around paths 

### DIFF
--- a/lib/dependency-manager-adapters/bower.js
+++ b/lib/dependency-manager-adapters/bower.js
@@ -185,7 +185,7 @@ module.exports = CoreObject.extend({
           });
       })
       .then(function(bowerPath) {
-        return path.join(bowerPath, '..', '..', 'bin', 'bower');
+        return '"' + path.join(bowerPath, '..', '..', 'bin', 'bower') + '"';
       });
   },
   _installBower: function() {

--- a/lib/utils/run-command.js
+++ b/lib/utils/run-command.js
@@ -13,7 +13,7 @@ module.exports = function(root, commandArgs, opts) {
 
   if (command === 'ember') {
     runPromise = findEmberPath(root).then(function(emberPath) {
-      return run('node', [].concat(emberPath, actualArgs), options);
+      return run('node', [].concat('"' + emberPath + '"', actualArgs), options);
     });
   } else {
     runPromise = run(command, actualArgs, options);


### PR DESCRIPTION
to prevent them from looking like separate arguments when run with the shell

fixes #149 