### PR TITLE
Implicitly add an npm dev dependency on bower

### DIFF
--- a/all-commands.sh
+++ b/all-commands.sh
@@ -31,46 +31,11 @@ ember try:ember '1.13.0' --skip-cleanup=true
 ember try:config
 ember try:config --config-path='test/fixtures/dummy-ember-try-config.js'
 
-# try:testall (Deprecated)
-ember try:testall
-
-# all styles of options for ember-try's own option
-ember try:testall --skip-cleanup
-ember try:testall --skip-cleanup=true
-ember try:testall --skip-cleanup true
-
 # config-path option
 ember try:testall --config-path='test/fixtures/dummy-ember-try-config.js'
 
 # both ember-try options
 ember try:testall --config-path='test/fixtures/dummy-ember-try-config.js' --skip-cleanup true
-
-# try <scenario>  (Deprecated)
-ember try default
-
-# custom command
-ember try default help
-
-# skip-cleanup option
-ember try default --skip-cleanup
-
-# The following two DO NOT CURRENTLY WORK
-# ember try default --skip-cleanup=true
-# ember try default --skip-cleanup true
-
-# config-path option; DOES NOT CURRENTLY WORK
-# ember try test1 --config-path='test/fixtures/dummy-ember-try-config.js'
-
-# both ember-try options; DOES NOT CURRENTLY WORK
-# ember try test1 --config-path='test/fixtures/dummy-ember-try-config.js' --skip-cleanup true
-
-# custom command with all styles of options
-ember try default help --silent
-ember try default help --silent=true
-ember try default help --silent true
-
-# custom command mixed with ember try's own option
-ember try default help --silent --skip-cleanup
 
 # try:one <scenario>
 ember try:one default
@@ -96,7 +61,6 @@ ember try:one default --- ember help --silent true
 
 # custom command mixed with ember try's own option
 ember try:one default --skip-cleanup --- ember help --silent
-
 
 # try:reset
 ember try:reset

--- a/lib/dependency-manager-adapters/bower.js
+++ b/lib/dependency-manager-adapters/bower.js
@@ -121,17 +121,6 @@ module.exports = CoreObject.extend({
     return adapter._findBowerPath(adapter.cwd).then(function(bowerPath) {
       debug('Run bower install using bower at %s', bowerPath);
       return adapter.run('node', [].concat([bowerPath], commandParts, options), { cwd: adapter.cwd });
-    }).catch(function() {
-      debug('Local bower not found');
-      return adapter._checkForGlobalBower().then(function() {
-        debug('Using global bower');
-        return adapter.run('bower', [].concat(commandParts, options), { cwd: adapter.cwd });
-      });
-    });
-  },
-  _checkForGlobalBower: function() {
-    return this.run('bower', ['-v'], { stdio: 'ignore' }).catch(function() {
-      throw new Error('Bower must be installed either locally or globally to have bower scenarios');
     });
   },
   _bowerJSONForDependencySet: function(bowerJSON, depSet) {

--- a/lib/dependency-manager-adapters/bower.js
+++ b/lib/dependency-manager-adapters/bower.js
@@ -108,17 +108,31 @@ module.exports = CoreObject.extend({
   },
   _install: function() {
     var adapter = this;
-    var options = this.managerOptions || [];
-
     return rimraf(path.join(adapter.cwd, 'bower_components'))
       .then(function() {
-        debug('Remove bower_components');
-        return adapter._findBowerPath(adapter.cwd);
-      })
-      .then(function(bowerPath) {
-        debug('Run bower install using bower at %s', bowerPath);
-        return adapter.run('node', [].concat([bowerPath, 'install', '--config.interactive=false'], options), { cwd: adapter.cwd });
+        debug('Removed bower_components');
+        return adapter._runBowerInstall();
       });
+  },
+  _runBowerInstall: function() {
+    var adapter = this;
+    var options = this.managerOptions || [];
+    var commandParts = ['install', '--config.interactive=false'];
+    return adapter._findBowerPath(adapter.cwd).then(function(bowerPath) {
+      debug('Run bower install using bower at %s', bowerPath);
+      return adapter.run('node', [].concat([bowerPath], commandParts, options), { cwd: adapter.cwd });
+    }).catch(function() {
+      debug('Local bower not found');
+      return adapter._checkForGlobalBower().then(function() {
+        debug('Using global bower');
+        return adapter.run('bower', [].concat(commandParts, options), { cwd: adapter.cwd });
+      });
+    });
+  },
+  _checkForGlobalBower: function() {
+    return this.run('bower', ['-v'], { stdio: 'ignore' }).catch(function() {
+      throw new Error('Bower must be installed either locally or globally to have bower scenarios');
+    });
   },
   _bowerJSONForDependencySet: function(bowerJSON, depSet) {
     if (!bowerJSON.resolutions) {
@@ -172,26 +186,13 @@ module.exports = CoreObject.extend({
   },
   _findBowerPath: function() {
     var adapter = this;
-    return findEmberPath(adapter.cwd)
-      .then(function(emberPath) {
-        /* Find bower's entry point module relative to
-         ember-cli's entry point script */
-        return adapter._resolveModule('bower', { basedir: path.dirname(emberPath) })
-          .catch(function() {
-            debug('Bower not found');
-            return adapter._installBower();
-          }).then(function() {
-            return adapter._resolveModule('bower', { basedir: path.dirname(emberPath) });
-          });
-      })
-      .then(function(bowerPath) {
-        return '"' + path.join(bowerPath, '..', '..', 'bin', 'bower') + '"';
-      });
-  },
-  _installBower: function() {
-    var adapter = this;
-    debug('Installing bower via npm');
-    return adapter.run('npm', [].concat(['install', 'bower@^1.3.12']), { cwd: adapter.cwd });
+    return findEmberPath(adapter.cwd).then(function(emberPath) {
+      /* Find bower's entry point module relative to ember-cli's entry point script */
+      return adapter._resolveModule('bower', { basedir: path.dirname(emberPath) })
+        .then(function(bowerPath) {
+          return '"' + path.join(bowerPath, '..', '..', 'bin', 'bower') + '"';
+        });
+    });
   },
   _resolveModule: function(moduleName, options) {
     return resolve(moduleName, options);

--- a/lib/utils/config.js
+++ b/lib/utils/config.js
@@ -7,7 +7,9 @@ var RSVP = require('rsvp');
 var findByName = require('./find-by-name');
 var debug = require('debug')('ember-try:utils:config');
 
-function config(options) {
+var IMPLICIT_BOWER_VERSION = '^1.8.2';
+
+function getBaseConfig(options) {
   var relativePath = options.configPath || path.join('config', 'ember-try.js');
   var configFile = path.join(options.project.root, relativePath);
   var configData;
@@ -39,7 +41,38 @@ function config(options) {
   }
 }
 
+function config(options) {
+  return getBaseConfig(options).then(function(configData) {
+    return addImplicitBowerToScenarios(configData);
+  });
+}
+
 module.exports = config;
+
+function addImplicitBowerToScenarios(configData) {
+  configData.scenarios.forEach(function(scenario) {
+    if (!('bower' in scenario)) {
+      // Don't do anything for scenarios that don't include bower
+      return;
+    }
+
+    if ('npm' in scenario) {
+      var npm = scenario.npm;
+      if ((npm.dependencies && npm.dependencies.bower) ||
+          (npm.devDependencies && npm.devDependencies.bower)) {
+        // Dont' do anything for scenarios that already include bower in npm,
+        // either as a dependency or a dev dependency
+        return;
+      }
+    }
+
+    // add an implicit bower dev dependency to npm for this scenario
+    scenario.npm = scenario.npm || {};
+    scenario.npm.devDependencies = scenario.npm.devDependencies || {};
+    scenario.npm.devDependencies.bower = IMPLICIT_BOWER_VERSION;
+  });
+  return configData;
+}
 
 function mergeAutoConfigAndConfigFileData(autoConfig, configData) {
   configData = configData || {};
@@ -77,7 +110,12 @@ function defaultConfig() {
           dependencies: { } /* No dependencies needed as the
                                default is already specified in
                                the consuming app's bower.json */
-        }
+        },
+        npm: {
+          devDependencies: {
+            bower: IMPLICIT_BOWER_VERSION,
+          }
+        },
       },
       {
         name: 'ember-release',
@@ -85,7 +123,12 @@ function defaultConfig() {
           dependencies: {
             ember: 'release'
           }
-        }
+        },
+        npm: {
+          devDependencies: {
+            bower: IMPLICIT_BOWER_VERSION,
+          }
+        },
       },
       {
         name: 'ember-beta',
@@ -93,7 +136,12 @@ function defaultConfig() {
           dependencies: {
             ember: 'beta'
           }
-        }
+        },
+        npm: {
+          devDependencies: {
+            bower: IMPLICIT_BOWER_VERSION,
+          }
+        },
       },
       {
         name: 'ember-canary',
@@ -101,7 +149,12 @@ function defaultConfig() {
           dependencies: {
             ember: 'canary'
           }
-        }
+        },
+        npm: {
+          devDependencies: {
+            bower: IMPLICIT_BOWER_VERSION,
+          }
+        },
       }
     ]
   };
@@ -109,3 +162,4 @@ function defaultConfig() {
 
 // Used for internal testing purposes.
 module.exports._defaultConfig = defaultConfig;
+module.exports._addImplicitBowerToScenarios = addImplicitBowerToScenarios;

--- a/lib/utils/run.js
+++ b/lib/utils/run.js
@@ -6,7 +6,8 @@ var debug = require('debug')('ember-try:utils:run');
 
 function run(command, args, opts) {
   opts = opts || {};
-  opts.stdio = 'inherit';
+
+  opts.stdio = opts.stdio || 'inherit';
 
   if (process.env.SHUT_UP) {
     opts.stdio = 'ignore';

--- a/test/tasks/try-each-test.js
+++ b/test/tasks/try-each-test.js
@@ -280,7 +280,6 @@ describe('tryEach', function() {
       });
     });
 
-
     it('fails scenarios when scenario\'s tests fail', function() {
       this.timeout(300000);
 

--- a/test/utils/config-test.js
+++ b/test/utils/config-test.js
@@ -9,6 +9,7 @@ var fixturePackage = require('../fixtures/package.json');
 var writeJSONFile = require('../helpers/write-json-file');
 var getConfig = require('../../lib/utils/config');
 var defaultConfig = getConfig._defaultConfig;
+var addImplicitBowerToScenarios = getConfig._addImplicitBowerToScenarios;
 
 var remove = RSVP.denodeify(fs.remove);
 var root = process.cwd();
@@ -36,6 +37,85 @@ describe('utils/config', function() {
     fs.writeFileSync('config/' + filename, contents, { encoding: 'utf8' });
   }
 
+  describe('addImplicitBowerToScenarios', function() {
+    it('adds an npm with a bower dev depencency for scenarios that have only bower', function() {
+      expect(addImplicitBowerToScenarios({
+        scenarios: [{
+          name: 'bower-only',
+          bower: { dependencies: {} },
+        }]
+      })).to.deep.equal({
+        scenarios: [{
+          name: 'bower-only',
+          bower: { dependencies: {} },
+          npm: { devDependencies: { bower: '^1.8.2' } },
+        }]
+      });
+    });
+
+    it('adds a bower dev dependency for scnearios that have bower and npm', function() {
+      expect(addImplicitBowerToScenarios({
+        scenarios: [{
+          name: 'bower-and-npm',
+          bower: { dependencies: {} },
+          npm: { devDependencies: { foo: 'latest' } },
+        }]
+      })).to.deep.equal({
+        scenarios: [{
+          name: 'bower-and-npm',
+          bower: { dependencies: {} },
+          npm: { devDependencies: { foo: 'latest', bower: '^1.8.2' } },
+        }]
+      });
+    });
+
+    it('does not add a bower dev dependency if a bower dev dependency is already present', function() {
+      expect(addImplicitBowerToScenarios({
+        scenarios: [{
+          name: 'bower-dev-dependency',
+          bower: { dependencies: {} },
+          npm: { devDependencies: { bower: '^1.8.2' } },
+        }]
+      })).to.deep.equal({
+        scenarios: [{
+          name: 'bower-dev-dependency',
+          bower: { dependencies: {} },
+          npm: { devDependencies: { bower: '^1.8.2' } },
+        }]
+      });
+    });
+
+    it('does not add a bower dev dependency if a bower dependency is already present', function() {
+      expect(addImplicitBowerToScenarios({
+        scenarios: [{
+          name: 'bower-dependency',
+          bower: { dependencies: {} },
+          npm: { dependencies: { bower: '^1.8.2' } },
+        }]
+      })).to.deep.equal({
+        scenarios: [{
+          name: 'bower-dependency',
+          bower: { dependencies: {} },
+          npm: { dependencies: { bower: '^1.8.2' } },
+        }]
+      });
+    });
+
+    it('does not add a bower dev dependency if bower is not present', function() {
+      expect(addImplicitBowerToScenarios({
+        scenarios: [{
+          name: 'no-bower',
+          npm: { devDependencies: { foo: 'latest' } },
+        }]
+      })).to.deep.equal({
+        scenarios: [{
+          name: 'no-bower',
+          npm: { devDependencies: { foo: 'latest' } },
+        }]
+      });
+    });
+  });
+
   it('uses specified options.configFile if present', function() {
     generateConfigFile('module.exports = { scenarios: [ { qux: "baz" }] };', 'non-default.js');
 
@@ -51,6 +131,29 @@ describe('utils/config', function() {
     return getConfig({ project: project }).then(function(config) {
       expect(config.scenarios).to.have.lengthOf(1);
       expect(config.scenarios[0].foo).to.equal('bar');
+    });
+  });
+
+  it('implicitly adds a bower dev dependency for npm for scenarios that include bower', function() {
+    generateConfigFile('module.exports = { scenarios: [ { bower: { dependencies: { foo: "latest" } } }] };');
+
+    return getConfig({ project: project }).then(function(config) {
+      expect(config.scenarios).to.have.lengthOf(1);
+      expect(config.scenarios[0]).to.deep.equal({
+        bower: { dependencies: { foo: 'latest' } },
+        npm: { devDependencies: { bower: '^1.8.2' } },
+      });
+    });
+  });
+
+  it('does not add a bower dependency for scenarios that do not include bower', function() {
+    generateConfigFile('module.exports = { scenarios: [ { npm: { dependencies: { foo: "latest" } } }] };');
+
+    return getConfig({ project: project }).then(function(config) {
+      expect(config.scenarios).to.have.lengthOf(1);
+      expect(config.scenarios[0]).to.deep.equal({
+        npm: { dependencies: { foo: 'latest' } },
+      });
     });
   });
 
@@ -98,23 +201,23 @@ describe('utils/config', function() {
       return getConfig({ project: project }).then(function(config) {
         expect(config).to.eql({
           scenarios: [
-            { name: 'default', bower: { dependencies: {} } },
+            { name: 'default', bower: { dependencies: {} }, npm: { devDependencies: { bower: '^1.8.2' } } },
             {
               name: 'ember-beta',
               allowedToFail: true,
               bower: { dependencies: { ember: 'components/ember#beta' }, resolutions: { ember: 'beta' } },
-              npm: { devDependencies: { 'ember-source': null } },
+              npm: { devDependencies: { 'ember-source': null, bower: '^1.8.2' } },
             },
             {
               name: 'ember-canary',
               allowedToFail: true,
               bower: { dependencies: { ember: 'components/ember#canary' }, resolutions: { ember: 'canary' } },
-              npm: { devDependencies: { 'ember-source': null } },
+              npm: { devDependencies: { 'ember-source': null, bower: '^1.8.2' } },
             },
             {
               name: 'ember-2.2.0',
               bower: { dependencies: { ember: '2.2.0' } },
-              npm: { devDependencies: { 'ember-source': null } },
+              npm: { devDependencies: { 'ember-source': null, bower: '^1.8.2' } },
             },
           ],
         });
@@ -126,24 +229,23 @@ describe('utils/config', function() {
       return getConfig({ project: project, versionCompatibility: { ember: '1.13.0' } }).then(function(config) {
         expect(config).to.eql({
           scenarios: [
-            { name: 'default', bower: { dependencies: {} } },
+            { name: 'default', bower: { dependencies: {} }, npm: { devDependencies: { bower: '^1.8.2' } } },
             {
               name: 'ember-beta',
               allowedToFail: true,
               bower: { dependencies: { ember: 'components/ember#beta' }, resolutions: { ember: 'beta' } },
-              npm: { devDependencies: { 'ember-source': null } },
+              npm: { devDependencies: { 'ember-source': null, bower: '^1.8.2' } },
             },
             {
               name: 'ember-canary',
               allowedToFail: true,
               bower: { dependencies: { ember: 'components/ember#canary' }, resolutions: { ember: 'canary' } },
-              npm: { devDependencies: { 'ember-source': null } },
+              npm: { devDependencies: { 'ember-source': null, bower: '^1.8.2' } },
             },
             {
               name: 'ember-1.13.0',
               bower: { dependencies: { ember: '1.13.0' } },
-
-              npm: { devDependencies: { 'ember-source': null } },
+              npm: { devDependencies: { 'ember-source': null, bower: '^1.8.2' } },
             },
             { foo: 'bar' },
           ],
@@ -155,26 +257,23 @@ describe('utils/config', function() {
       return getConfig({ project: project, versionCompatibility: { ember: '1.13.0' } }).then(function(config) {
         expect(config).to.eql({
           scenarios: [
-            { name: 'default', bower: { dependencies: {} } },
+            { name: 'default', bower: { dependencies: {} }, npm: { devDependencies: { bower: '^1.8.2' } } },
             {
               name: 'ember-beta',
               allowedToFail: true,
               bower: { dependencies: { ember: 'components/ember#beta' }, resolutions: { ember: 'beta' } },
-
-              npm: { devDependencies: { 'ember-source': null } },
+              npm: { devDependencies: { 'ember-source': null, bower: '^1.8.2' } },
             },
             {
               name: 'ember-canary',
               allowedToFail: true,
               bower: { dependencies: { ember: 'components/ember#canary' }, resolutions: { ember: 'canary' } },
-
-              npm: { devDependencies: { 'ember-source': null } },
+              npm: { devDependencies: { 'ember-source': null, bower: '^1.8.2' } },
             },
             {
               name: 'ember-1.13.0',
               bower: { dependencies: { ember: '1.13.0' } },
-
-              npm: { devDependencies: { 'ember-source': null } },
+              npm: { devDependencies: { 'ember-source': null, bower: '^1.8.2' } },
             },
           ],
         });
@@ -196,26 +295,27 @@ describe('utils/config', function() {
         expect(config).to.eql({
           bowerOptions: ['--allow-root=true'],
           scenarios: [
-            { name: 'default', bower: { dependencies: {} } },
+            {
+              name: 'default',
+              bower: { dependencies: {} },
+              npm: { devDependencies: { bower: '^1.8.2' } },
+            },
             {
               name: 'ember-beta',
               allowedToFail: true,
               bower: { dependencies: { ember: 'components/ember#beta' }, resolutions: { ember: 'beta' } },
-
-              npm: { devDependencies: { 'ember-source': null } },
+              npm: { devDependencies: { 'ember-source': null, bower: '^1.8.2' } },
             },
             {
               name: 'ember-canary',
               allowedToFail: true,
               bower: { dependencies: { ember: 'components/ember#canary' }, resolutions: { ember: 'canary' } },
-
-              npm: { devDependencies: { 'ember-source': null } },
+              npm: { devDependencies: { 'ember-source': null, bower: '^1.8.2' } },
             },
             {
               name: 'ember-2.2.0',
               bower: { dependencies: { ember: '2.2.0' } },
-
-              npm: { devDependencies: { 'ember-source': null } },
+              npm: { devDependencies: { 'ember-source': null, bower: '^1.8.2' } },
             },
           ],
         });
@@ -230,26 +330,27 @@ describe('utils/config', function() {
         expect(config.useVersionCompatibility).to.equal(true);
         expect(config.bowerOptions).to.eql(['--allow-root=true']);
         expect(config.scenarios).to.eql([
-          { name: 'default', bower: { dependencies: {} } },
+          {
+            name: 'default',
+            bower: { dependencies: {} },
+            npm: { devDependencies: { bower: '^1.8.2' } },
+          },
           {
             name: 'ember-beta',
             allowedToFail: false,
             bower: { dependencies: { ember: 'components/ember#beta' }, resolutions: { ember: 'beta' } },
-
-            npm: { devDependencies: { 'ember-source': null } },
+            npm: { devDependencies: { 'ember-source': null, bower: '^1.8.2' } },
           },
           {
             name: 'ember-canary',
             allowedToFail: true,
             bower: { dependencies: { ember: 'components/ember#canary' }, resolutions: { ember: 'canary' } },
-
-            npm: { devDependencies: { 'ember-source': null } },
+            npm: { devDependencies: { 'ember-source': null, bower: '^1.8.2' } },
           },
           {
             name: 'ember-2.2.0',
             bower: { dependencies: { ember: '2.2.0' } },
-
-            npm: { devDependencies: { 'ember-source': null } },
+            npm: { devDependencies: { 'ember-source': null, bower: '^1.8.2' } },
           },
           { name: 'bar' },
         ]);

--- a/test/utils/dependency-manager-adapter-factory-test.js
+++ b/test/utils/dependency-manager-adapter-factory-test.js
@@ -17,7 +17,7 @@ describe('DependencyManagerAdapterFactory', function() {
       expect(adapters.length).to.equal(1);
     });
 
-    it('creates both adapters when it has both keys', function() {
+    it('creates both adapters, with npm first, when it has both keys', function() {
       var adapters = DependencyManagerAdapterFactory.generateFromConfig({ scenarios: [{ bower: {}, npm: {} }] }, 'here');
       expect(adapters[0].configKey).to.equal('npm');
       expect(adapters[1].configKey).to.equal('bower');

--- a/test/utils/scenario-manager-test.js
+++ b/test/utils/scenario-manager-test.js
@@ -32,7 +32,7 @@ describe('scenarioManager', function() {
   });
 
   describe('#changeTo', function() {
-    it('changes dependency sets on each of the managers, and concats results', function() {
+    it('changes dependency sets on each of the managers, in order, and concats results', function() {
       var fakeAdapters = [
         new CoreObject({
           changeToDependencySet: function() {


### PR DESCRIPTION
For scenarios that
 1. do not already have a dependency or dev dependency on bower and
 2. have bower dependencies

Also assert that
 1. npm is ran before bower
 2. if bower is run, a local bower is found

This PR is a continuation of, and supersedes, #151.
Fixes #141 
Fixes #150