### PR TITLE
 Ensure `bower` is not required when no bower dependencies are present.

### DIFF
--- a/lib/dependency-manager-adapters/bower.js
+++ b/lib/dependency-manager-adapters/bower.js
@@ -7,7 +7,7 @@ var path = require('path');
 var extend = require('extend');
 var debug = require('debug')('ember-try:dependency-manager-adapter:bower');
 var rimraf = RSVP.denodeify(require('rimraf'));
-var resolve = RSVP.denodeify(require('resolve'));
+var resolve = require('resolve');
 var findEmberPath = require('../utils/find-ember-path');
 
 module.exports = CoreObject.extend({
@@ -54,13 +54,23 @@ module.exports = CoreObject.extend({
 
     fs.writeFileSync(bowerFile, JSON.stringify(newBowerJSON, null, 2));
   },
+  _hasDependencies(depSet) {
+    if (!depSet) { return false; }
+
+    var dependencies = Object.assign({}, depSet.dependencies, depSet.devDependencies);
+
+    return Object.keys(dependencies).length > 0;
+  },
+
   changeToDependencySet: function(depSet) {
     var adapter = this;
     depSet = this._getDependencySetAccountingForDeprecatedTopLevelKeys(depSet);
 
     debug('Changing to dependency set: %s', JSON.stringify(depSet));
 
-    if (!depSet) { return RSVP.resolve([]); }
+    if (!this._hasDependencies(depSet)) {
+      return RSVP.resolve([]);
+    }
 
     adapter._writeBowerFileWithDepSetChanges(depSet);
 
@@ -89,9 +99,9 @@ module.exports = CoreObject.extend({
       }).catch(function(e) {
         console.log('Error cleaning up bower scenario:', e);
       })
-      .then(function() {
-        return adapter._install();
-      });
+        .then(function() {
+          return adapter._install();
+        });
     } else {
       return rimraf(path.join(adapter.cwd, adapter.bowerJSONFileName)).then(function() {
         return rimraf(path.join(adapter.cwd, 'bower_components'));
@@ -177,13 +187,12 @@ module.exports = CoreObject.extend({
     var adapter = this;
     return findEmberPath(adapter.cwd).then(function(emberPath) {
       /* Find bower's entry point module relative to ember-cli's entry point script */
-      return adapter._resolveModule('bower', { basedir: path.dirname(emberPath) })
-        .then(function(bowerPath) {
-          return '"' + path.join(bowerPath, '..', '..', 'bin', 'bower') + '"';
-        });
+      var bowerPath = adapter._resolveModule('bower', { basedir: path.dirname(emberPath) });
+
+      return '"' + path.join(bowerPath, '..', '..', 'bin', 'bower') + '"';
     });
   },
   _resolveModule: function(moduleName, options) {
-    return resolve(moduleName, options);
+    return resolve.sync(moduleName, options);
   }
 });

--- a/lib/dependency-manager-adapters/bower.js
+++ b/lib/dependency-manager-adapters/bower.js
@@ -18,9 +18,11 @@ module.exports = CoreObject.extend({
   },
   bowerJSONFileName: 'bower.json',
   bowerJSONBackupFileName: 'bower.json.ember-try',
-  defaultBowerJSON: {
-    name: 'ember-try-placeholder',
-    dependencies: {}
+  defaultBowerJSON: function() {
+    return {
+      name: 'ember-try-placeholder',
+      dependencies: {},
+    };
   },
   configKey: 'bower',
   setup: function() {
@@ -45,7 +47,7 @@ module.exports = CoreObject.extend({
       var backupBowerFile = path.join(adapter.cwd, adapter.bowerJSONBackupFileName);
       baseBowerJSON = JSON.parse(fs.readFileSync(backupBowerFile));
     } else {
-      baseBowerJSON = this.defaultBowerJSON;
+      baseBowerJSON = this.defaultBowerJSON();
     }
 
     var newBowerJSON = adapter._bowerJSONForDependencySet(baseBowerJSON, depSet);
@@ -54,6 +56,11 @@ module.exports = CoreObject.extend({
 
     fs.writeFileSync(bowerFile, JSON.stringify(newBowerJSON, null, 2));
   },
+
+  /* Compute whether or not there are bower dependencies to install.
+   *
+   * @return true iff `depSet` has either dependencies or devDependencies
+   */
   _hasDependencies(depSet) {
     if (!depSet) { return false; }
 

--- a/lib/utils/dependency-manager-adapter-factory.js
+++ b/lib/utils/dependency-manager-adapter-factory.js
@@ -20,10 +20,8 @@ module.exports = {
         hasBower = true;
       }
     });
-    if (hasNpm) {
+    if (hasNpm || hasBower) {
       adapters.push(new NpmAdapter({ cwd: root, managerOptions: config.npmOptions, useYarnCommand: config.useYarn }));
-    }
-    if (hasBower) {
       adapters.push(new BowerAdapter({ cwd: root, managerOptions: config.bowerOptions }));
     }
     return adapters;

--- a/package.json
+++ b/package.json
@@ -48,7 +48,7 @@
     "glob": "^7.0.0",
     "istanbul": "1.0.0-alpha.2",
     "loader.js": "^4.0.1",
-    "mocha": "^2.2.5",
+    "mocha": "^4.0.0",
     "mockery": "^1.4.0",
     "tmp-sync": "^1.1.0"
   },

--- a/test/dependency-manager-adapters/bower-adapter-test.js
+++ b/test/dependency-manager-adapters/bower-adapter-test.js
@@ -89,7 +89,7 @@ describe('bowerAdapter', function() {
   });
 
   describe('#changeToDependencySet', function() {
-    it('if bower dependencies are not dependencies, nothing is done', function() {
+    it('if there are no bower dependencies, nothing is done', function() {
       var stubbedRun = function() {
         throw new Error('Should not run anything');
       };
@@ -118,14 +118,12 @@ describe('bowerAdapter', function() {
       };
 
       let adapter = new BowerAdapter({ cwd: tmpdir, run: stubbedRun });
-
       return adapter.setup()
         .then(function() {
           return adapter.changeToDependencySet({ dependencies: { 'ember': '*' } });
         })
         .then(function() {
           expect(stubbedRunRan).to.equal(true);
-          debugger
           return adapter.cleanup();
         });
     });
@@ -211,7 +209,6 @@ describe('bowerAdapter', function() {
 
   describe('#_writeBowerFileWithDepSetChanges', function() {
     it('writes bower.json with dep set changes', function() {
-      debugger
       var bowerJSON = { dependencies: { jquery: '1.11.1' }, resolutions: {} };
       var depSet = { dependencies: { jquery: '2.1.3' } };
       writeJSONFile('bower.json', bowerJSON);

--- a/test/tasks/try-each-test.js
+++ b/test/tasks/try-each-test.js
@@ -147,6 +147,8 @@ describe('tryEach', function() {
         _on: function() {}
       });
 
+      writeJSONFile('package.json', fixturePackage);
+      fs.mkdirSync('node_modules');
       writeJSONFile('bower.json', fixtureBower);
       return tryEachTask.run(legacyConfig.scenarios, {}).then(function(exitCode) {
         expect(exitCode).to.equal(0, 'exits 0 when all scenarios succeed');
@@ -191,6 +193,8 @@ describe('tryEach', function() {
         _on: function() {}
       });
 
+      writeJSONFile('package.json', fixturePackage);
+      fs.mkdirSync('node_modules');
       writeJSONFile('bower.json', fixtureBower);
       return tryEachTask.run(legacyConfig.scenarios, {}).then(function(exitCode) {
         expect(exitCode).to.equal(1);
@@ -230,6 +234,9 @@ describe('tryEach', function() {
         config: legacyConfig,
         _on: function() {}
       });
+
+      writeJSONFile('package.json', fixturePackage);
+      fs.mkdirSync('node_modules');
 
       expect(fs.existsSync('bower.json')).to.eql(false);
       return tryEachTask.run(legacyConfig.scenarios, {}).then(function() {

--- a/test/utils/dependency-manager-adapter-factory-test.js
+++ b/test/utils/dependency-manager-adapter-factory-test.js
@@ -5,35 +5,39 @@ var DependencyManagerAdapterFactory = require('../../lib/utils/dependency-manage
 
 describe('DependencyManagerAdapterFactory', function() {
   describe('generateFromConfig', function() {
-    it('creates npm adapter when config has npm key', function() {
+    it('creates both adapters, in order, when there is only an npm key', function() {
       var adapters = DependencyManagerAdapterFactory.generateFromConfig({ scenarios: [{ npm: {} }] }, 'here');
       expect(adapters[0].configKey).to.equal('npm');
-      expect(adapters.length).to.equal(1);
+      expect(adapters[1].configKey).to.equal('bower');
+      expect(adapters.length).to.equal(2);
     });
 
-    it('creates bower adapter when config has bower key', function() {
+    it('creates both adapters, in order, when there is only a bower key', function() {
       var adapters = DependencyManagerAdapterFactory.generateFromConfig({ scenarios: [{ bower: {} }] }, 'here');
-      expect(adapters[0].configKey).to.equal('bower');
-      expect(adapters.length).to.equal(1);
+      expect(adapters[0].configKey).to.equal('npm');
+      expect(adapters[1].configKey).to.equal('bower');
+      expect(adapters.length).to.equal(2);
     });
 
-    it('creates both adapters, with npm first, when it has both keys', function() {
+    it('creates both adapters, in order, when both keys are present', function() {
       var adapters = DependencyManagerAdapterFactory.generateFromConfig({ scenarios: [{ bower: {}, npm: {} }] }, 'here');
       expect(adapters[0].configKey).to.equal('npm');
       expect(adapters[1].configKey).to.equal('bower');
       expect(adapters.length).to.equal(2);
     });
 
-    it('creates bower adapter when legacy dependenies key', function() {
+    it('creates both adapters, in order, when there is only a legacy top-level dependencies', function() {
       var adapters = DependencyManagerAdapterFactory.generateFromConfig({ scenarios: [{ dependencies: {} }] }, 'here');
-      expect(adapters[0].configKey).to.equal('bower');
-      expect(adapters.length).to.equal(1);
+      expect(adapters[0].configKey).to.equal('npm');
+      expect(adapters[1].configKey).to.equal('bower');
+      expect(adapters.length).to.equal(2);
     });
 
-    it('creates bower adapter when legacy devDependencies key', function() {
+    it('creates both adapters, in order, when there is only a legacy top-level devDependencies', function() {
       var adapters = DependencyManagerAdapterFactory.generateFromConfig({ scenarios: [{ devDependencies: {} }] }, 'here');
-      expect(adapters[0].configKey).to.equal('bower');
-      expect(adapters.length).to.equal(1);
+      expect(adapters[0].configKey).to.equal('npm');
+      expect(adapters[1].configKey).to.equal('bower');
+      expect(adapters.length).to.equal(2);
     });
   });
 });


### PR DESCRIPTION
Fixes #161 