### PR TITLE
run `npm test` instead of `ember test` by default

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ This addon provides a few commands:
 
 ### `ember try:each`
 
-This command will run `ember test` or the configured command with each scenario's specified in the config and exit appropriately.
+This command will run `npm test` or the configured command with each scenario's specified in the config and exit appropriately.
 
 This command is especially useful to use on CI to test against multiple `ember` versions.
 
@@ -30,9 +30,9 @@ the `--config-path` option.
 If you need to know the scenario that is being run (i.e. to customize a test output file name) you can use the `EMBER_TRY_CURRENT_SCENARIO`
 environment variable.
 
-#### `ember try:one <scenario> (...options) --- <command (Default: ember test)>`
+#### `ember try:one <scenario> (...options) --- <command (Default: npm test)>`
 
-This command will run any `ember-cli` command with the specified scenario. The command will default to `ember test`, if no command is specified on the command-line or in configuration.
+This command will run any `ember-cli` command with the specified scenario. The command will default to `npm test`, if no command is specified on the command-line or in configuration.
 
 For example:
 
@@ -65,7 +65,7 @@ This command restores the original `bower.json` from `bower.json.ember-try`, `pa
 
 #### `ember try:ember <semver-string>`
 
-Runs `ember test` or the command in config for each version of Ember that is possible under the semver string given. Configuration follows the rules given under the `versionCompatibility` heading below.
+Runs `npm test` or the command in config for each version of Ember that is possible under the semver string given. Configuration follows the rules given under the `versionCompatibility` heading below.
 
 #### `ember try:config`
 

--- a/lib/commands/try-each.js
+++ b/lib/commands/try-each.js
@@ -3,7 +3,7 @@ let debug = require('debug')('ember-try:commands:try-each');
 
 module.exports = {
   name: 'try:each',
-  description: 'Runs each of the dependency scenarios specified in config with the specified command. The command defaults to `ember test`',
+  description: 'Runs each of the dependency scenarios specified in config with the specified command. The command defaults to `npm test`',
   works: 'insideProject',
 
   availableOptions: [

--- a/lib/commands/try-ember.js
+++ b/lib/commands/try-ember.js
@@ -3,7 +3,7 @@ let debug = require('debug')('ember-try:commands:try-ember');
 
 module.exports = {
   name: 'try:ember',
-  description: 'Runs with each Ember version matching the semver statement given. The command defaults to `ember test`',
+  description: 'Runs with each Ember version matching the semver statement given. The command defaults to `npm test`',
   works: 'insideProject',
 
   anonymousOptions: [

--- a/lib/commands/try-one.js
+++ b/lib/commands/try-one.js
@@ -4,7 +4,7 @@ let debug = require('debug')('ember-try:commands:try-one');
 
 module.exports = {
   name: 'try:one',
-  description: 'Run any `ember` command with the specified dependency scenario. This optional command is preceded by " --- " and will default to `ember test`',
+  description: 'Run any `ember` command with the specified dependency scenario. This optional command is preceded by " --- " and will default to `npm test`',
   works: 'insideProject',
 
   anonymousOptions: [

--- a/lib/tasks/try-each.js
+++ b/lib/tasks/try-each.js
@@ -122,7 +122,7 @@ module.exports = CoreObject.extend({
   },
 
   _defaultCommandArgs() {
-    return ['ember', 'test'];
+    return ['npm', 'test'];
   },
 
   _printResults(results) {

--- a/test/tasks/try-each-test.js
+++ b/test/tasks/try-each-test.js
@@ -90,7 +90,7 @@ describe('tryEach', () => {
     it('works without an initial bower.json', function() {
       this.timeout(300000);
 
-      let mockedRun = generateMockRun('ember test', () => {
+      let mockedRun = generateMockRun('npm test', () => {
         return RSVP.resolve(0);
       });
       mockery.registerMock('./run', mockedRun);
@@ -124,7 +124,7 @@ describe('tryEach', () => {
     it('succeeds when scenario\'s tests succeed', function() {
       this.timeout(300000);
 
-      let mockedRun = generateMockRun('ember test', () => {
+      let mockedRun = generateMockRun('npm test', () => {
         return RSVP.resolve(0);
       });
 
@@ -164,7 +164,7 @@ describe('tryEach', () => {
       this.timeout(300000);
 
       let runTestCount = 0;
-      let mockedRun = generateMockRun('ember test', () => {
+      let mockedRun = generateMockRun('npm test', () => {
         runTestCount++;
         if (runTestCount === 1) {
           return RSVP.reject(1);
@@ -277,7 +277,7 @@ describe('tryEach', () => {
           }],
         };
 
-        let mockedRun = generateMockRun('ember test', () => {
+        let mockedRun = generateMockRun('npm test', () => {
           return RSVP.reject(1);
         });
         mockery.registerMock('./run', mockedRun);
@@ -326,7 +326,7 @@ describe('tryEach', () => {
           }],
         };
 
-        let mockedRun = generateMockRun('ember test', () => {
+        let mockedRun = generateMockRun('npm test', () => {
           return RSVP.reject(1);
         });
         mockery.registerMock('./run', mockedRun);
@@ -376,7 +376,7 @@ describe('tryEach', () => {
           }],
         };
 
-        let mockedRun = generateMockRun('ember test', () => {
+        let mockedRun = generateMockRun('npm test', () => {
           return RSVP.resolve(0);
         });
         mockery.registerMock('./run', mockedRun);
@@ -409,7 +409,7 @@ describe('tryEach', () => {
     });
 
     describe('configurable command', () => {
-      it('defaults to `ember test`', function() {
+      it('defaults to `npm test`', function() {
         // With stubbed dependency manager, timing out is warning for accidentally not using the stub
         this.timeout(1200);
 
@@ -429,7 +429,7 @@ describe('tryEach', () => {
 
         let ranDefaultCommand = false;
 
-        let mockedRun = generateMockRun('ember test', () => {
+        let mockedRun = generateMockRun('npm test', () => {
           ranDefaultCommand = true;
           return RSVP.resolve(0);
         });


### PR DESCRIPTION
Since the default blueprint for addons now runs `ember test` instead of `ember try:each` for `npm test`, I think this should be the new default.

If someone customizes their "test" script, for example changing it to `ember exam`, their travis run is now out of sync. They would have to remember to go into ".travis.yml" and change to

```
- node_modules/.bin/ember try:one $EMBER_TRY_SCENARIO --skip-cleanup --- npm test
```

to keep them in sync. I think we should do this for them.