### PR TITLE
Update `cli-table2` to `cli-table3`

### DIFF
--- a/package.json
+++ b/package.json
@@ -60,7 +60,7 @@
   ],
   "dependencies": {
     "chalk": "^2.3.0",
-    "cli-table2": "^0.2.0",
+    "cli-table3": "^0.4.0",
     "core-object": "^3.1.5",
     "debug": "^3.1.0",
     "ember-try-config": "^3.0.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1567,6 +1567,16 @@ cli-table2@^0.2.0:
   optionalDependencies:
     colors "^1.1.2"
 
+cli-table3@^0.4.0:
+  version "0.4.0"
+  resolved "https://registry.yarnpkg.com/cli-table3/-/cli-table3-0.4.0.tgz#a7fd50f011d734e3f16403cfcbedbea97659e417"
+  dependencies:
+    kind-of "^3.0.4"
+    object-assign "^4.1.0"
+    string-width "^1.0.1"
+  optionalDependencies:
+    colors "^1.1.2"
+
 cli-table@^0.3.1:
   version "0.3.1"
   resolved "https://registry.yarnpkg.com/cli-table/-/cli-table-0.3.1.tgz#f53b05266a8b1a0b934b3d0821e6e2dc5914ae23"
@@ -4108,7 +4118,7 @@ keyv@3.0.0:
   dependencies:
     json-buffer "3.0.0"
 
-kind-of@^3.0.2, kind-of@^3.0.3, kind-of@^3.2.0:
+kind-of@^3.0.2, kind-of@^3.0.3, kind-of@^3.0.4, kind-of@^3.2.0:
   version "3.2.2"
   resolved "https://registry.yarnpkg.com/kind-of/-/kind-of-3.2.2.tgz#31ea21a734bab9bbb0f32466d893aea51e4a3c64"
   dependencies:


### PR DESCRIPTION
This PR updates the `cli-table2` dependency to `cli-table3`, which fixes one of the `npm audit` warnings :)

`cli-table2` (like `cli-table` itself) is no longer maintained. In jamestalmage/cli-table2#43 a couple of people have offered to take over maintenance but the current maintainer did not respond so as a result the project was forked to https://github.com/cli-table/cli-table3.
