### PR TITLE
[feat] Adds support for Yarn/NPM workspaces

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,7 +91,7 @@ If `useVersionCompatibility` is set to `true` in the config file, the autogenera
 
 To keep this from getting out of hand, `ember-try` will limit the versions of Ember used to the lasted point release per minor version. For example, ">1.11.0 <=2.0.0", would (as of writing) run with versions ['1.11.4', '1.12.2', '1.13.13', '2.0.0'].
 
-As of v1.0.0, This will only work for projects starting with ember provided by npm, not bower. 
+As of v1.0.0, This will only work for projects starting with ember provided by npm, not bower.
 
 ##### Configuration Files
 
@@ -196,11 +196,17 @@ The `name` can be used to try just one scenario using the `ember try:one` comman
 ##### Yarn
 
 If you include `useYarn: true` in your `ember-try` config, all npm scenarios will use `yarn` for install with the `--no-lockfile` option. At cleanup, your dependencies will be restored to their prior state.
- 
+
 ##### A note on npm scenarios with lockfiles
 
 Lockfiles are ignored by `ember-try`. (`yarn` will run with `--no-lockfile` and `npm` will be run with `--no-shrinkwrap`).
 When testing various scenarios, it's important to "float" dependencies so that the scenarios are run with the latest satisfying versions of dependencies a user of the project would get.
+
+##### Workspaces
+
+If you include `useWorkspaces: true` in your `ember-try` config, `ember-try` will apply the diff to each individual workspace specified
+in `package.json`, allowing you to try scenarios in monorepo style repositories. See
+[Yarn's documentation of workspaces](https://yarnpkg.com/lang/en/docs/workspaces/) for more details.
 
 ### Video
 [![How to use EmberTry](https://i.vimeocdn.com/video/559399937_500.jpg)](https://vimeo.com/157688157)

--- a/lib/dependency-manager-adapters/npm.js
+++ b/lib/dependency-manager-adapters/npm.js
@@ -30,19 +30,9 @@ module.exports = CoreObject.extend({
   },
   changeToDependencySet(depSet) {
     let adapter = this;
-    depSet = depSet[adapter.configKey];
 
-    debug('Changing to dependency set: %s', JSON.stringify(depSet));
+    adapter.applyDependencySet(depSet);
 
-    if (!depSet) { return RSVP.resolve([]); }
-    let backupPackageJSON = path.join(adapter.cwd, adapter.packageJSONBackupFileName);
-    let packageJSONFile = path.join(adapter.cwd, adapter.packageJSON);
-    let packageJSON = JSON.parse(fs.readFileSync(backupPackageJSON));
-    let newPackageJSON = adapter._packageJSONForDependencySet(packageJSON, depSet);
-
-    debug('Write package.json with: \n', JSON.stringify(newPackageJSON));
-
-    fs.writeFileSync(packageJSONFile, JSON.stringify(newPackageJSON, null, 2));
     return adapter._install().then(() => {
       let deps = extend({}, depSet.dependencies || {}, depSet.devDependencies || {});
       let currentDeps = Object.keys(deps).map((dep) => {
@@ -117,6 +107,21 @@ module.exports = CoreObject.extend({
         return adapter.run(adapter.configKey, ['prune'], { cwd: adapter.cwd });
       }
     });
+  },
+  applyDependencySet(depSet) {
+    depSet = depSet[this.configKey];
+
+    debug('Changing to dependency set: %s', JSON.stringify(depSet));
+
+    if (!depSet) { return RSVP.resolve([]); }
+    let backupPackageJSON = path.join(this.cwd, this.packageJSONBackupFileName);
+    let packageJSONFile = path.join(this.cwd, this.packageJSON);
+    let packageJSON = JSON.parse(fs.readFileSync(backupPackageJSON));
+    let newPackageJSON = this._packageJSONForDependencySet(packageJSON, depSet);
+
+    debug('Write package.json with: \n', JSON.stringify(newPackageJSON));
+
+    fs.writeFileSync(packageJSONFile, JSON.stringify(newPackageJSON, null, 2));
   },
   _packageJSONForDependencySet(packageJSON, depSet) {
 

--- a/lib/dependency-manager-adapters/workspace.js
+++ b/lib/dependency-manager-adapters/workspace.js
@@ -1,0 +1,102 @@
+'use strict';
+
+const CoreObject = require('core-object');
+const fs = require('fs-extra');
+const RSVP = require('rsvp');
+const path = require('path');
+const extend = require('extend');
+const debug = require('debug')('ember-try:dependency-manager-adapter:workspaces');
+const walkSync = require('walk-sync');
+
+const NpmAdapter = require('./npm');
+
+module.exports = CoreObject.extend({
+  init() {
+    this._super.apply(this, arguments);
+    this.run = this.run || require('../utils/run');
+
+    if (!this.useYarnCommand) {
+      throw new Error('workspaces are currently only supported by Yarn, you must set `useYarn` to true');
+    }
+  },
+
+  packageJSON: 'package.json',
+
+  setup(options) {
+    if (!options) {
+      options = {};
+    }
+
+    let packageJSON = JSON.parse(fs.readFileSync(this.packageJSON));
+    let workspaceGlobs = packageJSON.workspaces;
+
+    if (!workspaceGlobs || !workspaceGlobs.length) {
+      throw new Error('you must define the `workspaces` property in package.json with at least one workspace to use workspaces with ember-try');
+    }
+
+    // workspaces is a list of globs, loop over the list and find
+    // all paths that contain a `package.json` file
+    let workspacePaths = walkSync('.', { globs: workspaceGlobs }).filter(workspacePath => {
+      let packageJSONPath = path.join(this.cwd, workspacePath, 'package.json');
+      return fs.existsSync(packageJSONPath);
+    });
+
+    this._packageAdapters = workspacePaths.map(workspacePath => {
+      return new NpmAdapter({
+        cwd: workspacePath,
+        run: this.run,
+        managerOptions: this.managerOptions,
+        useYarnCommand: true,
+      });
+    });
+
+    return RSVP.all(this._packageAdapters.map(adapter => adapter.setup(options)));
+  },
+
+  changeToDependencySet(depSet) {
+    this._packageAdapters.forEach(adapter => {
+      adapter.applyDependencySet(depSet);
+    });
+
+    return this._install().then(() => {
+      let deps = extend({}, depSet.dependencies || {}, depSet.devDependencies || {});
+      let currentDeps = Object.keys(deps).map((dep) => {
+        return {
+          name: dep,
+          versionExpected: deps[dep],
+          versionSeen: this._findCurrentVersionOf(dep),
+          packageManager: 'yarn',
+        };
+      });
+
+      debug('Switched to dependencies: \n', currentDeps);
+
+      return RSVP.Promise.resolve(currentDeps);
+    });
+  },
+
+  cleanup() {
+    return RSVP.all(this._packageAdapters.map(adapter => adapter.cleanup()));
+  },
+
+  _install() {
+    let mgrOptions = this.managerOptions || [];
+
+    debug('Run yarn install with options %s', mgrOptions);
+
+    if (mgrOptions.indexOf('--no-lockfile') === -1) {
+      mgrOptions = mgrOptions.concat(['--no-lockfile']);
+    }
+    // npm warns on incompatible engines
+    // yarn errors, not a good experience
+    if (mgrOptions.indexOf('--ignore-engines') === -1) {
+      mgrOptions = mgrOptions.concat(['--ignore-engines']);
+    }
+
+    return this.run('yarn', [].concat(['install'], mgrOptions), { cwd: this.cwd });
+  },
+
+  _findCurrentVersionOf(dep) {
+    return this._packageAdapters[0]._findCurrentVersionOf(dep);
+  },
+});

--- a/lib/tasks/try-each.js
+++ b/lib/tasks/try-each.js
@@ -17,7 +17,8 @@ module.exports = CoreObject.extend({
     let task = this;
     let dependencyManagerAdapters = task.dependencyManagerAdapters || DependencyManagerAdapterFactory.generateFromConfig(task.config, task.project.root);
     debug('DependencyManagerAdapters: %s', dependencyManagerAdapters.map((item) => { return item.configKey; }));
-    task.ScenarioManager = new ScenarioManager({ ui: task.ui,
+    task.ScenarioManager = new ScenarioManager({
+      ui: task.ui,
       dependencyManagerAdapters,
     });
 

--- a/lib/utils/dependency-manager-adapter-factory.js
+++ b/lib/utils/dependency-manager-adapter-factory.js
@@ -2,6 +2,7 @@
 
 const BowerAdapter = require('../dependency-manager-adapters/bower');
 const NpmAdapter = require('../dependency-manager-adapters/npm');
+const WorkspaceAdapter = require('../dependency-manager-adapters/workspace');
 
 module.exports = {
   generateFromConfig(config, root) {
@@ -20,10 +21,24 @@ module.exports = {
         hasBower = true;
       }
     });
-    if (hasNpm || hasBower) {
+
+    if (config.useWorkspaces) {
+      if (hasBower) {
+        throw new Error('bower is not supported when using workspaces');
+      }
+
+      adapters.push(
+        new WorkspaceAdapter({
+          cwd: root,
+          managerOptions: config.npmOptions,
+          useYarnCommand: config.useYarn
+        })
+      );
+    } else if (hasNpm || hasBower) {
       adapters.push(new NpmAdapter({ cwd: root, managerOptions: config.npmOptions, useYarnCommand: config.useYarn }));
       adapters.push(new BowerAdapter({ cwd: root, managerOptions: config.bowerOptions }));
     }
+
     return adapters;
   },
 };

--- a/package.json
+++ b/package.json
@@ -71,7 +71,8 @@
     "promise-map-series": "^0.2.1",
     "resolve": "^1.1.6",
     "rimraf": "^2.3.2",
-    "rsvp": "^4.7.0"
+    "rsvp": "^4.7.0",
+    "walk-sync": "^0.3.3"
   },
   "ember-addon": {
     "configPath": "tests/dummy/config"

--- a/test/dependency-manager-adapters/workspace-adapter-test.js
+++ b/test/dependency-manager-adapters/workspace-adapter-test.js
@@ -1,0 +1,230 @@
+'use strict';
+
+let expect = require('chai').expect;
+let RSVP = require('rsvp');
+let fs = require('fs-extra');
+let path = require('path');
+let tmp = require('tmp-sync');
+let fixtureWorkspaces = require('../fixtures/package-with-workspaces.json');
+let WorkspaceAdapter = require('../../lib/dependency-manager-adapters/workspace');
+let writeJSONFile = require('../helpers/write-json-file');
+let generateMockRun = require('../helpers/generate-mock-run');
+
+let remove = RSVP.denodeify(fs.remove);
+let root = process.cwd();
+let tmproot = path.join(root, 'tmp');
+let tmpdir;
+
+describe('workspaceAdapter', () => {
+  beforeEach(() => {
+    tmpdir = tmp.in(tmproot);
+    process.chdir(tmpdir);
+    writeJSONFile('package.json', fixtureWorkspaces);
+  });
+
+  afterEach(() => {
+    process.chdir(root);
+    return remove(tmproot);
+  });
+
+  describe('#setup', () => {
+    it('backs up the package.json file and node_modules of subpackage', () => {
+      fs.ensureDirSync('packages/test/node_modules');
+
+      writeJSONFile('packages/test/package.json', { originalPackageJSON: true });
+      writeJSONFile('packages/test/node_modules/prove-it.json', { originalNodeModules: true });
+
+      return new WorkspaceAdapter({
+        cwd: tmpdir,
+        useYarnCommand: true,
+      }).setup().then(() => {
+        assertFileContainsJSON('packages/test/package.json.ember-try', { originalPackageJSON: true });
+        assertFileContainsJSON('packages/test/.node_modules.ember-try/prove-it.json', { originalNodeModules: true });
+      });
+    });
+
+    it('throws an error if workspaces are not present', () => {
+      writeJSONFile('package.json', {
+        name: 'a-test-project-with-workspaces'
+      });
+
+      expect(() => {
+        return new WorkspaceAdapter({
+          cwd: tmpdir,
+          useYarnCommand: true,
+        }).setup();
+      }).to.throw(/you must define the `workspaces` property in package.json with at least one workspace to use workspaces with ember-try/)
+    });
+  });
+
+  describe('#_install', () => {
+    describe('without yarn', () => {
+      it('throws an error', () => {
+        expect(() => {
+          return new WorkspaceAdapter({
+            cwd: tmpdir,
+          });
+        }).to.throw(/workspaces are currently only supported by Yarn, you must set `useYarn` to true/)
+      });
+    });
+
+    describe('with yarn', () => {
+      it('runs yarn install', () => {
+        let runCount = 0;
+        let stubbedRun = generateMockRun([{
+          command: 'yarn install --no-lockfile --ignore-engines',
+          callback(command, args, opts) {
+            runCount++;
+            expect(opts).to.have.property('cwd', tmpdir);
+            return RSVP.resolve();
+          },
+        }], { allowPassthrough: false });
+
+        return new WorkspaceAdapter({
+          cwd: tmpdir,
+          run: stubbedRun,
+          useYarnCommand: true,
+        })._install().then(() => {
+          expect(runCount).to.equal(1, 'Only yarn install should run');
+        });
+      });
+
+      it('uses managerOptions for yarn commands', () => {
+        let runCount = 0;
+        let stubbedRun = generateMockRun([{
+          command: 'yarn install --flat --no-lockfile --ignore-engines',
+          callback() {
+            runCount++;
+            return RSVP.resolve();
+          },
+        }], { allowPassthrough: false });
+
+        return new WorkspaceAdapter({
+          cwd: tmpdir,
+          run: stubbedRun,
+          useYarnCommand: true,
+          managerOptions: ['--flat'],
+        })._install().then(() => {
+          expect(runCount).to.equal(1, 'Only yarn install should run with manager options');
+        });
+      });
+    });
+  });
+
+  describe('#cleanup', () => {
+    it('replaces the package.json with the backed up version', () => {
+      fs.ensureDirSync('packages/test/node_modules');
+
+      writeJSONFile('packages/test/package.json', { originalPackageJSON: true });
+      writeJSONFile('packages/test/node_modules/prove-it.json', { originalNodeModules: true });
+
+      let workspaceAdapter = new WorkspaceAdapter({
+        cwd: tmpdir,
+        useYarnCommand: true,
+        run: () => Promise.resolve(),
+      });
+
+      return workspaceAdapter.setup().then(() => {
+        writeJSONFile('packages/test/package.json', { originalPackageJSON: false });
+        writeJSONFile('packages/test/node_modules/prove-it.json', { originalNodeModules: true });
+
+        return workspaceAdapter.cleanup();
+      }).then(() => {
+        assertFileContainsJSON('packages/test/package.json', { originalPackageJSON: true });
+        assertFileContainsJSON('packages/test/node_modules/prove-it.json', { originalNodeModules: true });
+      });
+    });
+  });
+
+  describe('#changeToDependencySet', () => {
+    let workspaceAdapter;
+
+    beforeEach(() => {
+      fs.ensureDirSync('packages/test/node_modules');
+      writeJSONFile('packages/test/package.json', {
+        devDependencies: { 'ember-feature-flags': '1.0.0' },
+        dependencies: { 'ember-cli-babel': '5.0.0' },
+        peerDependencies: { 'ember-cli-sass': '1.2.3' },
+      });
+
+      workspaceAdapter = new WorkspaceAdapter({
+        cwd: tmpdir,
+        useYarnCommand: true,
+        run: () => Promise.resolve(),
+      });
+
+      return workspaceAdapter.setup();
+    });
+
+    it('changes specified dependency versions', () => {
+      return workspaceAdapter.changeToDependencySet({
+        npm: {
+          dependencies: { 'ember-cli-babel': '6.0.0' },
+        },
+      }).then(() => {
+        assertFileContainsJSON('packages/test/package.json', {
+          devDependencies: { 'ember-feature-flags': '1.0.0' },
+          dependencies: { 'ember-cli-babel': '6.0.0' },
+          peerDependencies: { 'ember-cli-sass': '1.2.3' },
+        });
+      });
+    });
+
+    it('changes specified npm dev dependency versions', () => {
+      return workspaceAdapter.changeToDependencySet({
+        npm: {
+          devDependencies: { 'ember-feature-flags': '2.0.1' },
+        },
+      }).then(() => {
+        assertFileContainsJSON('packages/test/package.json', {
+          devDependencies: { 'ember-feature-flags': '2.0.1' },
+          dependencies: { 'ember-cli-babel': '5.0.0' },
+          peerDependencies: { 'ember-cli-sass': '1.2.3' },
+        });
+      });
+    });
+
+    it('changes specified npm peer dependency versions', () => {
+      return workspaceAdapter.changeToDependencySet({
+        npm: {
+          peerDependencies: { 'ember-cli-sass': '4.5.6' },
+        },
+      }).then(() => {
+        assertFileContainsJSON('packages/test/package.json', {
+          devDependencies: { 'ember-feature-flags': '1.0.0' },
+          dependencies: { 'ember-cli-babel': '5.0.0' },
+          peerDependencies: { 'ember-cli-sass': '4.5.6' },
+        });
+      });
+    });
+
+    it('can remove a package', () => {
+      return workspaceAdapter.changeToDependencySet({
+        npm: {
+          devDependencies: { 'ember-feature-flags': null },
+        },
+      }).then(() => {
+        assertFileContainsJSON('packages/test/package.json', {
+          devDependencies: {},
+          dependencies: { 'ember-cli-babel': '5.0.0' },
+          peerDependencies: { 'ember-cli-sass': '1.2.3' },
+        });
+      });
+    });
+  });
+});
+
+function assertFileContainsJSON(filename, expectedObj) {
+  return assertFileContains(filename, JSON.stringify(expectedObj, null, 2));
+}
+
+function assertFileContains(filename, expectedContents) {
+  let regex = new RegExp(`${escapeForRegex(expectedContents)}($|\\W)`, 'gm');
+  let actualContents = fs.readFileSync(path.join(tmpdir, filename), { encoding: 'utf-8' });
+  let result = regex.test(actualContents);
+  expect(result).to.equal(true, `File ${filename} is expected to contain ${expectedContents}`);
+}
+
+function escapeForRegex(str) {
+  return str.replace(/[-[\]{}()*+?.,\\^$|#]/g, '\\$&');
+}

--- a/test/fixtures/package-with-workspaces.json
+++ b/test/fixtures/package-with-workspaces.json
@@ -1,0 +1,6 @@
+{
+  "name": "a-test-project-with-workspaces",
+  "workspaces": [
+    "packages/*"
+  ]
+}

--- a/test/utils/dependency-manager-adapter-factory-test.js
+++ b/test/utils/dependency-manager-adapter-factory-test.js
@@ -2,6 +2,7 @@
 
 const expect = require('chai').expect;
 const DependencyManagerAdapterFactory = require('../../lib/utils/dependency-manager-adapter-factory');
+const WorkspaceAdapter = require('../../lib/dependency-manager-adapters/workspace');
 
 describe('DependencyManagerAdapterFactory', () => {
   describe('generateFromConfig', () => {
@@ -38,6 +39,26 @@ describe('DependencyManagerAdapterFactory', () => {
       expect(adapters[0].configKey).to.equal('npm');
       expect(adapters[1].configKey).to.equal('bower');
       expect(adapters.length).to.equal(2);
+    });
+
+    it('creates only a workspace adapter when useWorkspaces is set to true', () => {
+      let adapters = DependencyManagerAdapterFactory.generateFromConfig({
+        useYarn: true,
+        useWorkspaces: true,
+        scenarios: [{ npm: {} }]
+      });
+      expect(adapters[0]).to.be.instanceOf(WorkspaceAdapter);
+      expect(adapters.length).to.equal(1);
+    });
+
+    it('throws an error when attempting to use workspaces with bower dependencies', () => {
+      expect(() => {
+        DependencyManagerAdapterFactory.generateFromConfig({
+          useYarn: true,
+          useWorkspaces: true,
+          scenarios: [{ bower: {} }]
+        });
+      }).to.throw(/bower is not supported when using workspaces/);
     });
   });
 });

--- a/yarn.lock
+++ b/yarn.lock
@@ -6536,7 +6536,7 @@ walk-sync@^0.2.5, walk-sync@^0.2.7:
     ensure-posix-path "^1.0.0"
     matcher-collection "^1.0.0"
 
-walk-sync@^0.3.0, walk-sync@^0.3.1, walk-sync@^0.3.2:
+walk-sync@^0.3.0, walk-sync@^0.3.1, walk-sync@^0.3.2, walk-sync@^0.3.3:
   version "0.3.3"
   resolved "https://registry.yarnpkg.com/walk-sync/-/walk-sync-0.3.3.tgz#1e9f12cd4fe6e0e6d4a0715b5cc7e30711d43cd1"
   dependencies:


### PR DESCRIPTION
This PR adds support for workspaces to allow ember-try to run scenarios in monorepo based repositories quickly and efficiently. Workspaces are currently only supported by Yarn, but NPM has indicated that they [want to add support in the future](https://blog.npmjs.org/post/173239798780/beyond-npm6-the-future-of-the-npm-cli), and other tools for managing monorepos such as Lerna integrate nicely with workspaces, so it feels like the best way to add this type of support.

To enable workspaces, users need to install `ember-cli` and `ember-try` in the top level monorepo package, add a `config/ember-try.js` file, and set `useWorkspaces` and `useYarn` to true in that config. This means that the adapter is limited to using one try config for _all_ of the packages in the repo. For most monorepo use cases this should be sufficient, and users can still add ember-try to individual packages if needed for unique per-package scenarios.

The workspace adapter reuses the NPM adapter for each individual package. To do this, a new method needed to be exposed to allow depSets to be applied without running the install, since that needs to be done _once_ at the top level. An alternative would be to expose this as a task directly so it could be run as a command in each package, but that would be significantly more complicated.