### PR TITLE
Copy `useYarn` into example configuration file

### DIFF
--- a/README.md
+++ b/README.md
@@ -121,6 +121,11 @@ module.exports = function() {
       automatically generate scenarios that will deep merge with any in this configuration file.
     */
     useVersionCompatibility: true,
+    /*
+      If set to true, all npm scenarios will use `yarn` for install with the `--no-lockfile` option. At cleanup, your 
+      dependencies will be restored to their prior state.
+    */
+    useYarn: true,
     scenarios: [
       {
         name: 'Ember 1.10 with ember-data',


### PR DESCRIPTION
We should add the `useYarn` into the example ember-try configuration file. This PR also copies @backspace's documentation into a comment above it. Ping #168 

