### PR TITLE
Yarn resolutions

### DIFF
--- a/lib/dependency-manager-adapters/npm.js
+++ b/lib/dependency-manager-adapters/npm.js
@@ -124,15 +124,43 @@ module.exports = CoreObject.extend({
     fs.writeFileSync(packageJSONFile, JSON.stringify(newPackageJSON, null, 2));
   },
   _packageJSONForDependencySet(packageJSON, depSet) {
-
     this._overridePackageJSONDependencies(packageJSON, depSet, 'dependencies');
     this._overridePackageJSONDependencies(packageJSON, depSet, 'devDependencies');
     this._overridePackageJSONDependencies(packageJSON, depSet, 'peerDependencies');
 
+    if (this.useYarnCommand) {
+      this._addYarnResolutions(packageJSON, depSet);
+    }
+
     return packageJSON;
   },
+
+  _addYarnResolutions(packageJSON, depSet) {
+    if (!packageJSON.resolutions) {
+      packageJSON.resolutions = {};
+    }
+
+    let kinds = ['dependencies', 'devDependencies', 'peerDependencies'];
+    let packageVersions = kinds.reduce(
+      (all, kind) => Object.assign(all, depSet[kind]),
+      {}
+    );
+
+    let pkgs = Object.keys(packageVersions);
+
+    pkgs.forEach(pkg => {
+      let version = packageVersions[pkg];
+      if (version === null) {
+        delete packageJSON.resolutions[pkg]
+      } else {
+        packageJSON.resolutions[pkg] = version;
+      }
+    });
+  },
+
   _overridePackageJSONDependencies(packageJSON, depSet, kindOfDependency) {
     if (!depSet[kindOfDependency]) { return; }
+
     let pkgs = Object.keys(depSet[kindOfDependency]);
 
     pkgs.forEach((pkg) => {

--- a/test/dependency-manager-adapters/npm-adapter-test.js
+++ b/test/dependency-manager-adapters/npm-adapter-test.js
@@ -165,6 +165,61 @@ describe('npmAdapter', () => {
       expect(resultJSON.dependencies['ember-cli-babel']).to.equal('6.0.0');
     });
 
+    it('adds a resolution for the specified dependency version', () => {
+      let npmAdapter = new NpmAdapter({
+        cwd: tmpdir,
+        useYarnCommand: true
+      });
+      let packageJSON = {
+        dependencies: { 'ember-cli-babel': '5.0.0' },
+        devDependencies: { 'ember-data': '3.3.0' }
+      };
+      let depSet = {
+        dependencies: { 'ember-cli-babel': '6.0.0' },
+        devDependencies: { 'ember-data': '3.4.0' }
+      };
+
+      let resultJSON = npmAdapter._packageJSONForDependencySet(packageJSON, depSet);
+
+      expect(resultJSON.resolutions['ember-cli-babel']).to.equal('6.0.0');
+      expect(resultJSON.resolutions['ember-data']).to.equal('3.4.0');
+    });
+
+    it('deletes a resolution if the specified version is null', () => {
+      let npmAdapter = new NpmAdapter({
+        cwd: tmpdir,
+        useYarnCommand: true
+      });
+      let packageJSON = {
+        dependencies: { 'ember-cli-babel': '5.0.0' },
+        resolutions: { 'ember-cli-babel': '5.0.0' },
+      };
+      let depSet = { dependencies: { 'ember-cli-babel': null } };
+
+      let resultJSON = npmAdapter._packageJSONForDependencySet(packageJSON, depSet);
+
+      expect(resultJSON.resolutions['ember-cli-babel']).to.be.undefined;
+    });
+
+    it('doesnt add resolutions when not using yarn', () => {
+      let npmAdapter = new NpmAdapter({
+        cwd: tmpdir,
+        useYarnCommand: false
+      });
+      let packageJSON = {
+        dependencies: { 'ember-cli-babel': '5.0.0' },
+        devDependencies: { 'ember-data': '3.3.0' }
+      };
+      let depSet = {
+        dependencies: { 'ember-cli-babel': '6.0.0' },
+        devDependencies: { 'ember-data': '3.4.0' }
+      };
+
+      let resultJSON = npmAdapter._packageJSONForDependencySet(packageJSON, depSet);
+
+      expect(resultJSON.resolutions).to.be.undefined;
+    });
+
     it('changes specified npm dev dependency versions', () => {
       let npmAdapter = new NpmAdapter({ cwd: tmpdir });
       let packageJSON = { devDependencies: { 'ember-feature-flags': '1.0.0' }, dependencies: { 'ember-cli-babel': '5.0.0' } };

--- a/test/dependency-manager-adapters/workspace-adapter-test.js
+++ b/test/dependency-manager-adapters/workspace-adapter-test.js
@@ -166,6 +166,7 @@ describe('workspaceAdapter', () => {
           devDependencies: { 'ember-feature-flags': '1.0.0' },
           dependencies: { 'ember-cli-babel': '6.0.0' },
           peerDependencies: { 'ember-cli-sass': '1.2.3' },
+          resolutions: { 'ember-cli-babel': '6.0.0' }
         });
       });
     });
@@ -180,6 +181,7 @@ describe('workspaceAdapter', () => {
           devDependencies: { 'ember-feature-flags': '2.0.1' },
           dependencies: { 'ember-cli-babel': '5.0.0' },
           peerDependencies: { 'ember-cli-sass': '1.2.3' },
+          resolutions: { 'ember-feature-flags': '2.0.1' }
         });
       });
     });
@@ -194,6 +196,7 @@ describe('workspaceAdapter', () => {
           devDependencies: { 'ember-feature-flags': '1.0.0' },
           dependencies: { 'ember-cli-babel': '5.0.0' },
           peerDependencies: { 'ember-cli-sass': '4.5.6' },
+          resolutions: { 'ember-cli-sass': '4.5.6' }
         });
       });
     });
@@ -208,6 +211,7 @@ describe('workspaceAdapter', () => {
           devDependencies: {},
           dependencies: { 'ember-cli-babel': '5.0.0' },
           peerDependencies: { 'ember-cli-sass': '1.2.3' },
+          resolutions: {}
         });
       });
     });


### PR DESCRIPTION
When running the npm adapter with yarn this PR will add any version in the depSet to yarn resolutions. This will make sure the correct version gets installed.

See #208