### PR TITLE
TravisCI: Remove deprecated `sudo: false` option

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,8 +2,6 @@ language: node_js
 node_js:
 - '10'
 
-sudo: false
-
 dist: trusty
 
 addons:


### PR DESCRIPTION
see https://blog.travis-ci.com/2018-11-19-required-linux-infrastructure-migration