### PR TITLE
Add yarn resolutions

### DIFF
--- a/lib/dependency-manager-adapters/npm.js
+++ b/lib/dependency-manager-adapters/npm.js
@@ -129,6 +129,10 @@ module.exports = CoreObject.extend({
     this._overridePackageJSONDependencies(packageJSON, depSet, 'devDependencies');
     this._overridePackageJSONDependencies(packageJSON, depSet, 'peerDependencies');
 
+    if (this.useYarnCommand) {
+      this._overridePackageJSONDependencies(packageJSON, depSet, 'resolutions');
+    }
+
     return packageJSON;
   },
   _overridePackageJSONDependencies(packageJSON, depSet, kindOfDependency) {

--- a/test/dependency-manager-adapters/npm-adapter-test.js
+++ b/test/dependency-manager-adapters/npm-adapter-test.js
@@ -166,6 +166,78 @@ describe('npmAdapter', () => {
       expect(resultJSON.dependencies['ember-cli-babel']).to.equal('6.0.0');
     });
 
+    it('adds a resolution for the specified dependency version', () => {
+      let npmAdapter = new NpmAdapter({
+        cwd: tmpdir,
+        useYarnCommand: true
+      });
+      let packageJSON = {
+        dependencies: { 'ember-cli-babel': '5.0.0' },
+      };
+      let depSet = {
+        dependencies: { 'ember-cli-babel': '6.0.0' },
+        resolutions: { 'ember-cli-babel': '6.0.0' }
+      };
+
+      let resultJSON = npmAdapter._packageJSONForDependencySet(packageJSON, depSet);
+
+      expect(resultJSON.resolutions['ember-cli-babel']).to.equal('6.0.0');
+    });
+
+    it('removes a dependency from resolutions if its version is null', () => {
+      let npmAdapter = new NpmAdapter({
+        cwd: tmpdir,
+        useYarnCommand: true
+      });
+      let packageJSON = {
+        dependencies: { 'ember-cli-babel': '5.0.0' },
+        resolutions: { 'ember-cli-babel': '5.0.0' },
+      };
+      let depSet = {
+        dependencies: { 'ember-cli-babel': '6.0.0' },
+        resolutions: { 'ember-cli-babel': null },
+      };
+
+      let resultJSON = npmAdapter._packageJSONForDependencySet(packageJSON, depSet);
+
+      expect(resultJSON.resolutions['ember-cli-babel']).to.be.undefined;
+    });
+
+    it('doesnt add resolutions if there are none specified', () => {
+      let npmAdapter = new NpmAdapter({
+        cwd: tmpdir,
+        useYarnCommand: true
+      });
+      let packageJSON = {
+        dependencies: { 'ember-cli-babel': '5.0.0' },
+      };
+      let depSet = {
+        dependencies: { 'ember-cli-babel': '6.0.0' },
+      };
+
+      let resultJSON = npmAdapter._packageJSONForDependencySet(packageJSON, depSet);
+
+      expect(resultJSON.resolutions).to.be.undefined;
+    });
+
+    it('doesnt add resolutions when not using yarn', () => {
+      let npmAdapter = new NpmAdapter({
+        cwd: tmpdir,
+        useYarnCommand: false
+      });
+      let packageJSON = {
+        dependencies: { 'ember-cli-babel': '5.0.0' },
+      };
+      let depSet = {
+        dependencies: { 'ember-cli-babel': '6.0.0' },
+        resolutions: { 'ember-cli-babel': '6.0.0' }
+      };
+
+      let resultJSON = npmAdapter._packageJSONForDependencySet(packageJSON, depSet);
+
+      expect(resultJSON.resolutions).to.be.undefined;
+    });
+
     it('changes specified npm dev dependency versions', () => {
       let npmAdapter = new NpmAdapter({ cwd: tmpdir });
       let packageJSON = { devDependencies: { 'ember-feature-flags': '1.0.0' }, dependencies: { 'ember-cli-babel': '5.0.0' } };

--- a/test/dependency-manager-adapters/workspace-adapter-test.js
+++ b/test/dependency-manager-adapters/workspace-adapter-test.js
@@ -146,6 +146,7 @@ describe('workspaceAdapter', () => {
         devDependencies: { 'ember-feature-flags': '1.0.0' },
         dependencies: { 'ember-cli-babel': '5.0.0' },
         peerDependencies: { 'ember-cli-sass': '1.2.3' },
+        resolutions: { 'ember-data': '3.0.0' },
       });
 
       workspaceAdapter = new WorkspaceAdapter({
@@ -167,6 +168,7 @@ describe('workspaceAdapter', () => {
           devDependencies: { 'ember-feature-flags': '1.0.0' },
           dependencies: { 'ember-cli-babel': '6.0.0' },
           peerDependencies: { 'ember-cli-sass': '1.2.3' },
+          resolutions: { 'ember-data': '3.0.0' },
         });
       });
     });
@@ -181,6 +183,7 @@ describe('workspaceAdapter', () => {
           devDependencies: { 'ember-feature-flags': '2.0.1' },
           dependencies: { 'ember-cli-babel': '5.0.0' },
           peerDependencies: { 'ember-cli-sass': '1.2.3' },
+          resolutions: { 'ember-data': '3.0.0' },
         });
       });
     });
@@ -195,6 +198,22 @@ describe('workspaceAdapter', () => {
           devDependencies: { 'ember-feature-flags': '1.0.0' },
           dependencies: { 'ember-cli-babel': '5.0.0' },
           peerDependencies: { 'ember-cli-sass': '4.5.6' },
+          resolutions: { 'ember-data': '3.0.0' },
+        });
+      });
+    });
+
+    it('changes specified resolution versions', () => {
+      return workspaceAdapter.changeToDependencySet({
+        npm: {
+          resolutions: { 'ember-data': '3.5.0' },
+        },
+      }).then(() => {
+        assertFileContainsJSON('packages/test/package.json', {
+          devDependencies: { 'ember-feature-flags': '1.0.0' },
+          dependencies: { 'ember-cli-babel': '5.0.0' },
+          peerDependencies: { 'ember-cli-sass': '1.2.3' },
+          resolutions: { 'ember-data': '3.5.0' },
         });
       });
     });
@@ -209,6 +228,7 @@ describe('workspaceAdapter', () => {
           devDependencies: {},
           dependencies: { 'ember-cli-babel': '5.0.0' },
           peerDependencies: { 'ember-cli-sass': '1.2.3' },
+          resolutions: { 'ember-data': '3.0.0' },
         });
       });
     });


### PR DESCRIPTION
This PR adds resolution support for ember-try configs that are using yarn.
It uses the same merging strategy that the dependencies, devDependencies, and
peerDependencies use.