### PR TITLE
fixing npm@5 and npm@6

### DIFF
--- a/lib/dependency-manager-adapters/npm.js
+++ b/lib/dependency-manager-adapters/npm.js
@@ -83,7 +83,6 @@ module.exports = CoreObject.extend({
     }
   },
   _install() {
-    let adapter = this;
     let mgrOptions = this.managerOptions || [];
 
     debug('Run npm install with options %s', mgrOptions);
@@ -102,11 +101,7 @@ module.exports = CoreObject.extend({
       mgrOptions = mgrOptions.concat(['--no-shrinkwrap']);
     }
 
-    return this.run(cmd, [].concat(['install'], mgrOptions), { cwd: this.cwd }).then(() => {
-      if (!adapter.useYarnCommand) {
-        return adapter.run(adapter.configKey, ['prune'], { cwd: adapter.cwd });
-      }
-    });
+    return this.run(cmd, [].concat(['install'], mgrOptions), { cwd: this.cwd });
   },
   applyDependencySet(depSet) {
     depSet = depSet[this.configKey];

--- a/test/dependency-manager-adapters/npm-adapter-test.js
+++ b/test/dependency-manager-adapters/npm-adapter-test.js
@@ -52,20 +52,13 @@ describe('npmAdapter', () => {
             expect(opts).to.have.property('cwd', tmpdir);
             return RSVP.resolve();
           },
-        }, {
-          command: 'npm prune',
-          callback(command, args, opts) {
-            runCount++;
-            expect(opts).to.have.property('cwd', tmpdir);
-            return RSVP.resolve();
-          },
         }], { allowPassthrough: false });
 
         return new NpmAdapter({
           cwd: tmpdir,
           run: stubbedRun,
         })._install().then(() => {
-          expect(runCount).to.equal(2, 'Both commands should run');
+          expect(runCount).to.equal(1);
         });
       });
 
@@ -78,12 +71,6 @@ describe('npmAdapter', () => {
             runCount++;
             return RSVP.resolve();
           },
-        }, {
-          command: 'npm prune',
-          callback() {
-            runCount++;
-            return RSVP.resolve();
-          },
         }], { allowPassthrough: false });
 
         return new NpmAdapter({
@@ -91,7 +78,7 @@ describe('npmAdapter', () => {
           run: stubbedRun,
           managerOptions: ['--no-optional'],
         })._install().then(() => {
-          expect(runCount).to.equal(2, 'Both commands should run');
+          expect(runCount).to.equal(1);
         });
       });
     });


### PR DESCRIPTION
Fixes #167 

I think the explanation of this is that npm now manages pruning automatically since npm@5 and we should not be doing it manually at all. 

The documentation [here](https://docs.npmjs.com/cli/prune.html) seems to be suggesting that if you run prune when you have not updated your package-lock.json it will remove the new dependency which seems to be the case here