### PR TITLE
Vastly reduce appveyor testing. Keep it to one smoke-test only.

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -28,14 +28,7 @@ test_script:
   - cmd: cd smoke-test-app
   - cmd: yarn upgrade "ember-try@../ember-try-%ran%.tgz"
   - cmd: yarn install
-  - cmd: node_modules/.bin/ember try:each
-  - cmd: node_modules/.bin/ember try:ember "~2.10.0 || ~3.7.0"
-  - cmd: node_modules/.bin/ember try:config --config-path="../test/fixtures/dummy-ember-try-config.js"
-  - cmd: node_modules/.bin/ember try:one default
-  - cmd: node_modules/.bin/ember try:one default --- ember help
   - cmd: node_modules/.bin/ember try:one test1 --config-path="../test/fixtures/dummy-ember-try-config.js"
-  - cmd: node_modules/.bin/ember try:one default --skip-cleanup --- ember help --json
-  - cmd: node_modules/.bin/ember try:reset
 
 # Don't actually build.
 build: off


### PR DESCRIPTION
It keeps timing out. This balances keeping some windows smoke-testing
against being able to to develop at all.

I will continue investigating alternatives, but so far none have worked out (Travis Windows, Azure Pipelines). 