### PR TITLE
Restore backup files before changing to new dependency set for new scenarios.

### DIFF
--- a/lib/dependency-manager-adapters/npm.js
+++ b/lib/dependency-manager-adapters/npm.js
@@ -59,7 +59,7 @@ module.exports = CoreObject.extend({
 
   async cleanup() {
     try {
-      await this._restoreOriginalDependencies();
+      await this.restoreOriginalDependencies();
 
       debug('Remove backup package.json and node_modules');
 
@@ -204,7 +204,7 @@ module.exports = CoreObject.extend({
     });
   },
 
-  _restoreOriginalDependencies() {
+  restoreOriginalDependencies() {
     debug('Restoring original package.json and node_modules');
 
     let restoreTasks = [

--- a/lib/dependency-manager-adapters/workspace.js
+++ b/lib/dependency-manager-adapters/workspace.js
@@ -85,6 +85,12 @@ module.exports = CoreObject.extend({
     return currentDeps;
   },
 
+  restoreOriginalDependencies() {
+    return Promise.all(
+      this._packageAdapters.map((adapter) => adapter.restoreOriginalDependencies())
+    );
+  },
+
   cleanup() {
     return Promise.all(this._packageAdapters.map((adapter) => adapter.cleanup()));
   },

--- a/lib/tasks/try-each.js
+++ b/lib/tasks/try-each.js
@@ -97,6 +97,8 @@ module.exports = CoreObject.extend({
     runResults.result = result;
     this._writeFooter(`Result: ${result}`);
 
+    await this.ScenarioManager.restoreOriginalDependencies();
+
     return runResults;
   },
 

--- a/lib/tasks/try-each.js
+++ b/lib/tasks/try-each.js
@@ -40,6 +40,10 @@ module.exports = CoreObject.extend({
       let results = [];
       for (let scenario of scenarios) {
         results.push(await this._runCommandForThisScenario(scenario));
+
+        if (scenarios.length > 1) {
+          await this.ScenarioManager.restoreOriginalDependencies();
+        }
       }
 
       await this._optionallyCleanup(options);
@@ -96,8 +100,6 @@ module.exports = CoreObject.extend({
 
     runResults.result = result;
     this._writeFooter(`Result: ${result}`);
-
-    await this.ScenarioManager.restoreOriginalDependencies();
 
     return runResults;
   },

--- a/lib/utils/scenario-manager.js
+++ b/lib/utils/scenario-manager.js
@@ -41,4 +41,10 @@ module.exports = CoreObject.extend({
       await depManager.cleanup();
     }
   },
+
+  async restoreOriginalDependencies() {
+    for (let depManager of this.dependencyManagerAdapters) {
+      await depManager.restoreOriginalDependencies();
+    }
+  },
 });

--- a/test/dependency-manager-adapters/npm-adapter-test.js
+++ b/test/dependency-manager-adapters/npm-adapter-test.js
@@ -354,13 +354,13 @@ describe('npmAdapter', () => {
     });
   });
 
-  describe('#_restoreOriginalDependencies', () => {
+  describe('#restoreOriginalDependencies', () => {
     it('replaces the package.json with the backed up version', () => {
       writeJSONFile('package.json.ember-try', { originalPackageJSON: true });
       writeJSONFile('package.json', { originalPackageJSON: false });
       fs.mkdirSync('.node_modules.ember-try');
       writeJSONFile('.node_modules.ember-try/prove-it.json', { originalNodeModules: true });
-      return new NpmAdapter({ cwd: tmpdir })._restoreOriginalDependencies().then(() => {
+      return new NpmAdapter({ cwd: tmpdir }).restoreOriginalDependencies().then(() => {
         assertFileContainsJSON(path.join(tmpdir, 'package.json'), { originalPackageJSON: true });
         assertFileContainsJSON(path.join(tmpdir, 'node_modules/prove-it.json'), {
           originalNodeModules: true,
@@ -379,7 +379,7 @@ describe('npmAdapter', () => {
       writeJSONFile('npm-shrinkwrap.json', { originalNpmShrinkWrap: false });
       writeJSONFile('package-lock.json.ember-try', { originalPackageLock: true });
       writeJSONFile('package-lock.json', { originalPackageLock: false });
-      return new NpmAdapter({ cwd: tmpdir })._restoreOriginalDependencies().then(() => {
+      return new NpmAdapter({ cwd: tmpdir }).restoreOriginalDependencies().then(() => {
         assertFileContainsJSON(path.join(tmpdir, 'package.json'), { originalPackageJSON: true });
         assertFileContainsJSON(path.join(tmpdir, 'node_modules/prove-it.json'), {
           originalNodeModules: true,

--- a/test/helpers/stub-dependency-manager-adapter.js
+++ b/test/helpers/stub-dependency-manager-adapter.js
@@ -1,22 +1,21 @@
 'use strict';
 
 const CoreObject = require('core-object');
-const RSVP = require('rsvp');
 
 module.exports = CoreObject.extend({
-  setup() {
-    return RSVP.resolve();
-  },
-  changeToDependencySet() {
-    return RSVP.resolve([
+  async setup() {},
+
+  async changeToDependencySet() {
+    return [
       {
         name: 'testDep',
         versionExpected: '2.0.0',
         versionSeen: '2.1.0',
       },
-    ]);
+    ];
   },
-  cleanup() {
-    return RSVP.resolve();
-  },
+
+  async restoreOriginalDependencies() {},
+
+  async cleanup() {},
 });


### PR DESCRIPTION
This PR is created to fix an issue we are having when using `buildManagerOptions` and removing the default `--no-lockfile` option in order to use our yarn.lock file.  In the current behavior, when switching between scenarios, versions from the previous scenario gets carried over to the next scenario, which is not the ideal behavior that we want. We want to reset the yarn.lock to the original version, before changing the dependencies of the new scenario.

In order to accomplish this, we will restore all backups before installing new dependencies for the new scenario. This will not affect the current default behavior for those with default settings, but will greatly improve the experience of those who are using `buildManagerOptions` to override the default `--no-lockfile`.