### PR TITLE
Handle additional `yarn` workspace definition formats

### DIFF
--- a/lib/dependency-manager-adapters/npm.js
+++ b/lib/dependency-manager-adapters/npm.js
@@ -194,9 +194,12 @@ module.exports = CoreObject.extend({
     let restoreTasks = [
       copy(path.join(this.cwd, this.packageJSONBackupFileName),
         path.join(this.cwd, this.packageJSON)),
-      copy(path.join(this.cwd, this.nodeModulesBackupLocation),
-        path.join(this.cwd, this.nodeModules), { clobber: true }),
     ];
+
+    if (fs.existsSync(path.join(this.cwd, this.nodeModulesBackupLocation))) {
+      restoreTasks.push(copy(path.join(this.cwd, this.nodeModulesBackupLocation),
+        path.join(this.cwd, this.nodeModules), { clobber: true }));
+    }
 
     if (fs.existsSync(path.join(this.cwd, this.yarnLockBackupFileName))) {
       restoreTasks.push(copy(path.join(this.cwd, this.yarnLockBackupFileName),
@@ -222,9 +225,12 @@ module.exports = CoreObject.extend({
 
     let backupTasks = [
       copy(path.join(this.cwd, this.packageJSON),
-        path.join(this.cwd, this.packageJSONBackupFileName)),
-      copy(path.join(this.cwd, this.nodeModules),
-        path.join(this.cwd, this.nodeModulesBackupLocation), { clobber: true })];
+        path.join(this.cwd, this.packageJSONBackupFileName))];
+
+    if (fs.existsSync(path.join(this.cwd, this.nodeModules))) {
+      backupTasks.push(copy(path.join(this.cwd, this.nodeModules),
+        path.join(this.cwd, this.nodeModulesBackupLocation), { clobber: true }));
+    }
 
     if (fs.existsSync(path.join(this.cwd, this.yarnLock))) {
       backupTasks.push(copy(path.join(this.cwd, this.yarnLock),

--- a/lib/dependency-manager-adapters/workspace.js
+++ b/lib/dependency-manager-adapters/workspace.js
@@ -28,10 +28,14 @@ module.exports = CoreObject.extend({
     }
 
     let packageJSON = JSON.parse(fs.readFileSync(this.packageJSON));
-    let workspaceGlobs = packageJSON.workspaces
+    let workspaceGlobs;
 
-    if (workspaceGlobs && workspaceGlobs.packages) {
-      workspaceGlobs = workspaceGlobs.packages
+    if (Array.isArray(packageJSON.workspaces)) {
+      workspaceGlobs = packageJSON.workspaces
+    }
+
+    if (packageJSON.workspaces && Array.isArray(packageJSON.workspaces.packages)) {
+      workspaceGlobs = packageJSON.workspaces.packages
     }
 
     if (!workspaceGlobs || !workspaceGlobs.length) {

--- a/lib/dependency-manager-adapters/workspace.js
+++ b/lib/dependency-manager-adapters/workspace.js
@@ -28,7 +28,11 @@ module.exports = CoreObject.extend({
     }
 
     let packageJSON = JSON.parse(fs.readFileSync(this.packageJSON));
-    let workspaceGlobs = packageJSON.workspaces;
+    let workspaceGlobs = packageJSON.workspaces
+
+    if (workspaceGlobs && workspaceGlobs.packages) {
+      workspaceGlobs = workspaceGlobs.packages
+    }
 
     if (!workspaceGlobs || !workspaceGlobs.length) {
       throw new Error('you must define the `workspaces` property in package.json with at least one workspace to use workspaces with ember-try');

--- a/test/dependency-manager-adapters/workspace-adapter-test.js
+++ b/test/dependency-manager-adapters/workspace-adapter-test.js
@@ -44,6 +44,33 @@ describe('workspaceAdapter', () => {
       });
     });
 
+    it('with workspace packages', () => {
+      writeJSONFile('package.json', {
+        name: 'a-test-project-with-workspaces',
+        workspaces: {
+          packages: [
+            "packages/*"
+          ],
+          nohoist: [
+            '@foo/example'
+          ]
+        }
+      })
+
+      fs.ensureDirSync('packages/test/node_modules');
+
+      writeJSONFile('packages/test/package.json', { originalPackageJSON: true });
+      writeJSONFile('packages/test/node_modules/prove-it.json', { originalNodeModules: true });
+
+      return new WorkspaceAdapter({
+        cwd: tmpdir,
+        useYarnCommand: true,
+      }).setup().then(() => {
+        assertFileContainsJSON(path.join(tmpdir, 'packages/test/package.json.ember-try'), { originalPackageJSON: true });
+        assertFileContainsJSON(path.join(tmpdir, 'packages/test/.node_modules.ember-try/prove-it.json'), { originalNodeModules: true });
+      });
+    });
+
     it('backs up the yarn.lock file, npm-shrinkwrap.json and package-lock.json if they exist', () => {
       fs.ensureDirSync('packages/test/node_modules');
 


### PR DESCRIPTION
Yarn workspaces can have two [different definitions](https://classic.yarnpkg.com/blog/2018/02/15/nohoist/)

```
"workspaces": [
  "packages/*"
]
```

and

```
"workspaces": {
  "packages": ["packages/*"],
  "nohoist": ["**/react-native", "**/react-native/**"]
}
```

This PR adds support for the second definition