### PR TITLE
Ensure Yarn Workspace adapter supports `ember try:reset`.

### DIFF
--- a/lib/dependency-manager-adapters/workspace.js
+++ b/lib/dependency-manager-adapters/workspace.js
@@ -18,15 +18,6 @@ module.exports = CoreObject.extend({
     if (!this.useYarnCommand) {
       throw new Error('workspaces are currently only supported by Yarn, you must set `useYarn` to true');
     }
-  },
-
-  packageJSON: 'package.json',
-
-  setup(options) {
-    if (!options) {
-      options = {};
-    }
-
     let packageJSON = JSON.parse(fs.readFileSync(this.packageJSON));
     let workspaceGlobs;
 
@@ -58,6 +49,15 @@ module.exports = CoreObject.extend({
         buildManagerOptions: this.buildManagerOptions,
       });
     });
+
+  },
+
+  packageJSON: 'package.json',
+
+  setup(options) {
+    if (!options) {
+      options = {};
+    }
 
     return RSVP.all(this._packageAdapters.map(adapter => adapter.setup(options)));
   },

--- a/test/dependency-manager-adapters/workspace-adapter-test.js
+++ b/test/dependency-manager-adapters/workspace-adapter-test.js
@@ -195,6 +195,29 @@ describe('workspaceAdapter', () => {
   });
 
   describe('#cleanup', () => {
+    it('works without having called #setup first', () => {
+      fs.ensureDirSync('packages/test/node_modules');
+
+      writeJSONFile('packages/test/package.json', { originalPackageJSON: false });
+      writeJSONFile('packages/test/node_modules/prove-it.json', { originalNodeModules: false });
+
+      let workspaceAdapter = new WorkspaceAdapter({
+        cwd: tmpdir,
+        useYarnCommand: true,
+        run: () => Promise.resolve(),
+      });
+
+      fs.ensureDirSync('packages/test/.node_modules.ember-try');
+
+      writeJSONFile('packages/test/package.json.ember-try', { originalPackageJSON: true });
+      writeJSONFile('packages/test/.node_modules.ember-try/prove-it.json', { originalNodeModules: true });
+
+      return workspaceAdapter.cleanup().then(() => {
+        assertFileContainsJSON(path.join(tmpdir, 'packages/test/package.json'), { originalPackageJSON: true });
+        assertFileContainsJSON(path.join(tmpdir, 'packages/test/node_modules/prove-it.json'), { originalNodeModules: true });
+      });
+    });
+
     it('replaces the package.json with the backed up version', () => {
       fs.ensureDirSync('packages/test/node_modules');
 


### PR DESCRIPTION
Fundamentally, `Adapter.prototype.cleanup` **cannot** require `Adatper.prototype.setup` to have been called. _Most_ of the time `.setup` is called before `.cleanup` (this happens with `ember try:each` and `ember try:one`), but when `--skip-cleanup` is specified (e.g.  `ember try:one scenario-name --skip-cleanup`) and you subsequently run `ember try:reset` the `.setup` happened in a completely different process.

The issue here is a misunderstanding when we added the `WorkspaceAdapter` initially. Basically, the assumtion was that `.setup` was for setting up both local instance state (e.g. the `this._packageAdapters` array) **and** for actually preparing for a `ember try:...` run (doing backups / etc).

The fix is to move the internal state setup code directly into `init`/`constructor, and ensure that `.setup` is only used to create the backups themselves.

Fixes #466