### PR TITLE
Drop support for Node.js 6.x, 8.x, 11.x and 13.x

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -62,7 +62,7 @@ jobs:
   npm-smoke-tests:
     strategy:
       matrix:
-        node: ['8', '10', '12', '14']
+        node: ['10', '12', '14']
 
     name: Tests (Node.js v${{ matrix.node }} with npm)
     runs-on: ubuntu-latest
@@ -84,7 +84,7 @@ jobs:
   yarn-smoke-tests:
     strategy:
       matrix:
-        node: ['8', '10', '12', '14']
+        node: ['10', '12', '14']
 
     name: Tests (Node.js v${{ matrix.node }} with yarn)
     runs-on: ubuntu-latest

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -5,7 +5,7 @@ skip_branch_with_pr: true
 environment:
   MOCHA_REPORTER: "mocha-appveyor-reporter"
   matrix:
-    - nodejs_version: "6"
+    - nodejs_version: "10"
 
 # Install scripts. (runs after repo cloning)
 install:

--- a/package.json
+++ b/package.json
@@ -84,7 +84,7 @@
     "tmp-sync": "^1.1.0"
   },
   "engines": {
-    "node": "6.* || 8.* || >= 10.*"
+    "node": "10.* || 12.* || >= 14.*"
   },
   "ember-addon": {
     "configPath": "tests/dummy/config"


### PR DESCRIPTION
which should match our support matrix to all of the currently officially supported Node.js versions.