### PR TITLE
Use `ember-addon.configPath` from `package.json` if defined.

### DIFF
--- a/index.js
+++ b/index.js
@@ -3,7 +3,7 @@
 module.exports = {
   name: 'ember-try',
 
-  includedCommands: function() {
+  includedCommands() {
     return require('./lib/commands');
   }
 };

--- a/lib/commands/config.js
+++ b/lib/commands/config.js
@@ -7,7 +7,7 @@ module.exports = {
   description: 'Displays the config that will be used',
   works: 'insideProject',
   availableOptions: [
-    { name: 'config-path', type: String, default: 'config/ember-try.js' },
+    { name: 'config-path', type: String },
   ],
 
   async run(commandOptions) {

--- a/lib/commands/try-each.js
+++ b/lib/commands/try-each.js
@@ -8,7 +8,7 @@ module.exports = {
 
   availableOptions: [
     { name: 'skip-cleanup',  type: Boolean, default: false },
-    { name: 'config-path', type: String, default: 'config/ember-try.js' },
+    { name: 'config-path', type: String },
   ],
 
   _getConfig: require('../utils/config'),

--- a/lib/commands/try-ember.js
+++ b/lib/commands/try-ember.js
@@ -13,7 +13,7 @@ module.exports = {
 
   availableOptions: [
     { name: 'skip-cleanup',  type: Boolean, default: false },
-    { name: 'config-path', type: String, default: 'config/ember-try.js' },
+    { name: 'config-path', type: String },
   ],
 
   _getConfig: require('../utils/config'),

--- a/lib/utils/config.js
+++ b/lib/utils/config.js
@@ -7,17 +7,36 @@ const debug = require('debug')('ember-try:utils:config');
 
 const IMPLICIT_BOWER_VERSION = '^1.8.2';
 
+function getConfigPath(project) {
+  let possibleConfigPath;
+  if (project.pkg && project.pkg['ember-addon'] && project.pkg['ember-addon']['configPath']) {
+    let configDir = project.pkg['ember-addon']['configPath'];
+
+    possibleConfigPath = path.join(configDir, 'ember-try.js');
+  }
+
+  if (fs.existsSync(possibleConfigPath)) {
+    debug(`using config from package.json ember-addon.configPath: ${possibleConfigPath}`);
+
+    return possibleConfigPath;
+  }
+
+  debug('using config from config/ember-try.js');
+
+  return path.join('config', 'ember-try.js');
+}
+
 async function getBaseConfig(options) {
-  let relativePath = options.configPath || path.join('config', 'ember-try.js');
-  let configFile = path.join(options.project.root, relativePath);
+  let relativeConfigPath = options.configPath || getConfigPath(options.project);
+  let configPath = path.join(options.project.root, relativeConfigPath);
   let data;
 
-  if (fs.existsSync(configFile)) {
-    let configData = await require(configFile);
+  if (fs.existsSync(configPath)) {
+    let configData = await require(configPath);
 
     data = typeof configData === 'function' ? await configData(options.project) : configData;
   } else {
-    debug('Config file does not exist %s', configFile);
+    debug('Config file does not exist %s', configPath);
   }
 
   if (data && data.scenarios && !data.useVersionCompatibility && !options.versionCompatibility) {


### PR DESCRIPTION
This makes `ember-try` work much closer to how other ecosystem tools work (`@ember/optional-features`, `ember-cli`'s lookup of `config/environment.js` and `config/targets.js`, `ember-cli-code-coverage`).

This is not a breaking change, as it still falls back to using the older hardcoded `config/ember-try.js` path.

Fixes https://github.com/ember-cli/ember-try/issues/305
