### PR TITLE
Limit SemVer range smoke test to > 2.16 < 3.0.0.

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -68,7 +68,7 @@ jobs:
           - ./node_modules/.bin/ember try:each --config-path='../test/fixtures/dummy-ember-try-config.js' --skip-cleanup true
 
           # try:ember
-          - ./node_modules/.bin/ember try:ember '> 2.10.0 < 3.0.0'
+          - ./node_modules/.bin/ember try:ember '> 2.16.0 < 3.0.0'
           - ./node_modules/.bin/ember try:ember '2.10.0' --config-path='../test/fixtures/dummy-ember-try-config.js'
           - ./node_modules/.bin/ember try:ember '3.2.0' --skip-cleanup=true
 


### PR DESCRIPTION
This will reduce the overall number of scenarios that we run through for
that one smoke test job.
