### PR TITLE
CI: Remove job schedule

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,8 +6,6 @@ on:
       - master
       - 'v*'
   pull_request: {}
-  schedule:
-    - cron: '0 3 * * *' # daily, at 3am
 
 jobs:
   lint:


### PR DESCRIPTION
Scheduled jobs are automatically disabled after a certain amount of days, thanks to the cryptocurrency community.

This commit removes the schedule to keep the job enabled for PRs and regular commits

/cc @kategengler 