### PR TITLE
Use `dereference` when copying node_modules

### DIFF
--- a/lib/dependency-manager-adapters/npm.js
+++ b/lib/dependency-manager-adapters/npm.js
@@ -217,7 +217,10 @@ module.exports = CoreObject.extend({
     let nodeModulesBackupLocation = path.join(this.cwd, this.nodeModulesBackupLocation);
     if (fs.existsSync(nodeModulesBackupLocation)) {
       restoreTasks.push(
-        copy(nodeModulesBackupLocation, path.join(this.cwd, this.nodeModules), { clobber: true })
+        copy(nodeModulesBackupLocation, path.join(this.cwd, this.nodeModules), {
+          overwrite: true,
+          dereference: true,
+        })
       );
     }
 
@@ -253,7 +256,8 @@ module.exports = CoreObject.extend({
     if (fs.existsSync(nodeModulesPath)) {
       backupTasks.push(
         copy(nodeModulesPath, path.join(this.cwd, this.nodeModulesBackupLocation), {
-          clobber: true,
+          overwrite: true,
+          dereference: true,
         })
       );
     }

--- a/package.json
+++ b/package.json
@@ -35,7 +35,7 @@
     "debug": "^4.3.2",
     "ember-try-config": "^4.0.0",
     "execa": "^4.1.0",
-    "fs-extra": "^9.0.1",
+    "fs-extra": "^9.1.0",
     "resolve": "^1.20.0",
     "rimraf": "^3.0.2",
     "walk-sync": "^2.2.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -3469,7 +3469,7 @@ fs-extra@^8.0.1, fs-extra@^8.1.0:
     jsonfile "^4.0.0"
     universalify "^0.1.0"
 
-fs-extra@^9.0.0, fs-extra@^9.0.1:
+fs-extra@^9.0.0:
   version "9.0.1"
   resolved "https://registry.yarnpkg.com/fs-extra/-/fs-extra-9.0.1.tgz#910da0062437ba4c39fedd863f1675ccfefcb9fc"
   integrity sha512-h2iAoN838FqAFJY2/qVpzFXy+EBxfVE220PalAqQLDVsFOHLJrZvut5puAbCdNv6WJk+B8ihI+k0c7JK5erwqQ==
@@ -3478,6 +3478,16 @@ fs-extra@^9.0.0, fs-extra@^9.0.1:
     graceful-fs "^4.2.0"
     jsonfile "^6.0.1"
     universalify "^1.0.0"
+
+fs-extra@^9.1.0:
+  version "9.1.0"
+  resolved "https://registry.yarnpkg.com/fs-extra/-/fs-extra-9.1.0.tgz#5954460c764a8da2094ba3554bf839e6b9a7c86d"
+  integrity sha512-hcg3ZmepS30/7BSFqRvoo3DOMQu7IjqxO5nCDt+zM9XWjb33Wg7ziNT+Qvqbuc3+gWpzO02JubVyk2G4Zvo1OQ==
+  dependencies:
+    at-least-node "^1.0.0"
+    graceful-fs "^4.2.0"
+    jsonfile "^6.0.1"
+    universalify "^2.0.0"
 
 fs-merger@^3.1.0:
   version "3.1.0"
@@ -8003,6 +8013,11 @@ universalify@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/universalify/-/universalify-1.0.0.tgz#b61a1da173e8435b2fe3c67d29b9adf8594bd16d"
   integrity sha512-rb6X1W158d7pRQBg5gkR8uPaSfiids68LTJQYOtEUhoJUWBdaQHsuT/EUduxXYxcrt4r5PJ4fuHW1MHT6p0qug==
+
+universalify@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/universalify/-/universalify-2.0.0.tgz#75a4984efedc4b08975c5aeb73f530d02df25717"
+  integrity sha512-hAZsKq7Yy11Zu1DE0OzWjw7nnLZmJZYTDZZyEFHZdUhV8FkH5MCfoU1XMaxXovpyW5nq5scPqq0ZDP9Zyl04oQ==
 
 unpipe@1.0.0, unpipe@~1.0.0:
   version "1.0.0"


### PR DESCRIPTION
- `clobber` option to fs-extra#copy was renamed to `overwrite` way back in v2
- Upgrade fs-extra


Fixes #813

This can also be fixed by removing the backing up and restoring of node_modules, which we suspect is no longer necessary. The only use case I recalled for it was restoring node_modules exactly (including any linked packages), which this change would already no longer support.