### PR TITLE
Add support for npm overrides

### DIFF
--- a/README.md
+++ b/README.md
@@ -144,6 +144,14 @@ module.exports = async function() {
             'ember-source': '2.11.0'
           },
           /*
+            You can optionally define npm overrides to enforce a  specific dependency version
+            to be installed. This is useful if other libraries you depend on include different
+            versions of a package. This does nothing if `useYarn` is true;
+          */
+          overrides: {
+            'lodash': '5.0.0'
+          }
+          /*
             When `useYarn` is true, you can optionally define yarn resolutions to enforce a
             specific dependency version to be installed. This is useful if other libraries
             you depend on include different versions of a package.

--- a/lib/dependency-manager-adapters/npm.js
+++ b/lib/dependency-manager-adapters/npm.js
@@ -178,6 +178,8 @@ module.exports = CoreObject.extend({
 
     if (this.useYarnCommand) {
       this._overridePackageJSONDependencies(packageJSON, depSet, 'resolutions');
+    } else {
+      this._overridePackageJSONDependencies(packageJSON, depSet, 'overrides');
     }
 
     return packageJSON;

--- a/test/dependency-manager-adapters/npm-adapter-test.js
+++ b/test/dependency-manager-adapters/npm-adapter-test.js
@@ -536,6 +536,75 @@ describe('npmAdapter', () => {
       expect(resultJSON.resolutions).to.be.undefined;
     });
 
+    it('adds a override for the specified dependency version', () => {
+      let npmAdapter = new NpmAdapter({
+        cwd: tmpdir,
+      });
+      let packageJSON = {
+        dependencies: { 'ember-cli-babel': '5.0.0' },
+      };
+      let depSet = {
+        dependencies: { 'ember-cli-babel': '6.0.0' },
+        overrides: { 'ember-cli-babel': '6.0.0' },
+      };
+
+      let resultJSON = npmAdapter._packageJSONForDependencySet(packageJSON, depSet);
+
+      expect(resultJSON.overrides['ember-cli-babel']).to.equal('6.0.0');
+    });
+
+    it('removes a dependency from overrides if its version is null', () => {
+      let npmAdapter = new NpmAdapter({
+        cwd: tmpdir,
+      });
+      let packageJSON = {
+        dependencies: { 'ember-cli-babel': '5.0.0' },
+        overrides: { 'ember-cli-babel': '5.0.0' },
+      };
+      let depSet = {
+        dependencies: { 'ember-cli-babel': '6.0.0' },
+        overrides: { 'ember-cli-babel': null },
+      };
+
+      let resultJSON = npmAdapter._packageJSONForDependencySet(packageJSON, depSet);
+
+      expect(resultJSON.overrides['ember-cli-babel']).to.be.undefined;
+    });
+
+    it('doesnt add overrides if there are none specified', () => {
+      let npmAdapter = new NpmAdapter({
+        cwd: tmpdir,
+      });
+      let packageJSON = {
+        dependencies: { 'ember-cli-babel': '5.0.0' },
+      };
+      let depSet = {
+        dependencies: { 'ember-cli-babel': '6.0.0' },
+      };
+
+      let resultJSON = npmAdapter._packageJSONForDependencySet(packageJSON, depSet);
+
+      expect(resultJSON.resolutions).to.be.undefined;
+    });
+
+    it('doesnt add overrides when using yarn', () => {
+      let npmAdapter = new NpmAdapter({
+        cwd: tmpdir,
+        useYarnCommand: true,
+      });
+      let packageJSON = {
+        dependencies: { 'ember-cli-babel': '5.0.0' },
+      };
+      let depSet = {
+        dependencies: { 'ember-cli-babel': '6.0.0' },
+        overrides: { 'ember-cli-babel': '6.0.0' },
+      };
+
+      let resultJSON = npmAdapter._packageJSONForDependencySet(packageJSON, depSet);
+
+      expect(resultJSON.overrides).to.be.undefined;
+    });
+
     it('changes specified npm dev dependency versions', () => {
       let npmAdapter = new NpmAdapter({ cwd: tmpdir });
       let packageJSON = {


### PR DESCRIPTION
This PR is supposed to help with the issue that is described in https://github.com/emberjs/ember-render-modifiers/issues/64

Essentially npm thinks that ranges shouldn't be satisfied if you are using pre-releases. You can overcome this if you use an `overrides` in npm which works in a very similar way to yarn resolutions. 

The issue is that if you provide an `overrides` config to ember-try it will just ignore it: 

```
{
  name: 'ember-release',
  npm: {
    devDependencies: {
      'ember-source': await getChannelURL('release'),
    },
    overrides: {
      'ember-source': '$ember-source',
    },
  },
},
```

This PR implements npm overrides in much the same way as yarn resolutions 👍  in fact I copy and pasted all of the resolutions tests and just changed resolutions to overrides in most cases 😂 