### PR TITLE
Fixed version of ember-try-test-suite-helper

### DIFF
--- a/test/fixtures/package.json
+++ b/test/fixtures/package.json
@@ -1,7 +1,7 @@
 {
   "name": "a-test-project",
   "devDependencies": {
-    "ember-try-test-suite-helper": "0.0.1"
+    "ember-try-test-suite-helper": "1.0.0"
   },
   "repository": "kategengler/ember-try",
   "private": true,


### PR DESCRIPTION
on newer version of npm it was throwing an error because of incorrect version in a fixture.

This PR fixes it