### PR TITLE
Downgraded fs-extra version to 6.x to fix a fs.copy related issue.

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -46,6 +46,8 @@ updates:
   - dependency-name: eslint-plugin-prettier
     versions:
     - 3.3.1
+  - dependency-name: fs-extra
+    update-types: ["version-update:semver-major"]
 - package-ecosystem: npm
   directory: "/smoke-test-app"
   schedule:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -115,6 +115,8 @@ jobs:
           # Environment variables from config
           - ./node_modules/.bin/ember try:each --config-path='../test/fixtures/dummy-ember-try-config-different-env-vars.js'
 
+          # fs-extra versions 7.x and above caused a regresion
+          - ./node_modules/.bin/ember try:each --config-path='../test/fixtures/dummy-ember-try-config-fs-extra-scenarios.js'
 
     steps:
       - uses: actions/checkout@v1

--- a/package.json
+++ b/package.json
@@ -35,7 +35,7 @@
     "debug": "^4.3.2",
     "ember-try-config": "^4.0.0",
     "execa": "^4.1.0",
-    "fs-extra": "^9.0.1",
+    "fs-extra": "^6.0.1",
     "resolve": "^1.20.0",
     "rimraf": "^3.0.2",
     "walk-sync": "^2.2.0"

--- a/test/fixtures/dummy-ember-try-config-fs-extra-scenarios.js
+++ b/test/fixtures/dummy-ember-try-config-fs-extra-scenarios.js
@@ -1,0 +1,24 @@
+module.exports = {
+  scenarios: [
+    {
+      name: 'Ember try should succeed when using fs-extra version 6.x',
+      npm: {
+        devDependencies: {
+          'watchpack-chokidar2': '2.0.1',
+          'ember-try-test-suite-helper': '1.0.0',
+          'fs-extra': '6.0.1',
+        },
+      },
+    },
+    {
+      name: 'Ember try should fail when using fs-extra version 9.x',
+      npm: {
+        devDependencies: {
+          'watchpack-chokidar2': '2.0.1',
+          'ember-try-test-suite-helper': '1.0.0',
+          'fs-extra': '9.0.1',
+        },
+      },
+    },
+  ],
+};

--- a/yarn.lock
+++ b/yarn.lock
@@ -3460,6 +3460,15 @@ fs-extra@^5.0.0:
     jsonfile "^4.0.0"
     universalify "^0.1.0"
 
+fs-extra@^6.0.1:
+  version "6.0.1"
+  resolved "https://registry.yarnpkg.com/fs-extra/-/fs-extra-6.0.1.tgz#8abc128f7946e310135ddc93b98bddb410e7a34b"
+  integrity sha512-GnyIkKhhzXZUWFCaJzvyDLEEgDkPfb4/TPvJCJVuS8MWZgoSsErf++QpiAlDnKFcqhRlm+tIOcencCjyJE6ZCA==
+  dependencies:
+    graceful-fs "^4.1.2"
+    jsonfile "^4.0.0"
+    universalify "^0.1.0"
+
 fs-extra@^8.0.1, fs-extra@^8.1.0:
   version "8.1.0"
   resolved "https://registry.yarnpkg.com/fs-extra/-/fs-extra-8.1.0.tgz#49d43c45a88cd9677668cb7be1b46efdb8d2e1c0"
@@ -3469,7 +3478,7 @@ fs-extra@^8.0.1, fs-extra@^8.1.0:
     jsonfile "^4.0.0"
     universalify "^0.1.0"
 
-fs-extra@^9.0.0, fs-extra@^9.0.1:
+fs-extra@^9.0.0:
   version "9.0.1"
   resolved "https://registry.yarnpkg.com/fs-extra/-/fs-extra-9.0.1.tgz#910da0062437ba4c39fedd863f1675ccfefcb9fc"
   integrity sha512-h2iAoN838FqAFJY2/qVpzFXy+EBxfVE220PalAqQLDVsFOHLJrZvut5puAbCdNv6WJk+B8ihI+k0c7JK5erwqQ==


### PR DESCRIPTION
fs-extra brought in a breaking change here:
https://github.com/jprichardson/node-fs-extra/pull/582

where it breaks ember-try when copying node_modules/ and there's a symlink in it. The bug would either prevent ember-try from running or cleaning up after try-each.

Testing done:
`yarn test` passed locally.

@Co-authored-by hjdivad