### PR TITLE
Bump node to supported versions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,6 +15,8 @@ jobs:
     steps:
       - uses: actions/checkout@v1
       - uses: actions/setup-node@v1
+        with:
+          node-version: 14
 
       - run: yarn install
       - run: yarn lint
@@ -26,6 +28,8 @@ jobs:
     steps:
       - uses: actions/checkout@v1
       - uses: actions/setup-node@v1
+        with:
+          node-version: 14
 
       - run: yarn install
       - run: yarn node-test-with-coverage
@@ -37,6 +41,8 @@ jobs:
     steps:
       - uses: actions/checkout@v1
       - uses: actions/setup-node@v1
+        with:
+          node-version: 14
 
       - run: yarn install --no-lockfile
       - run: yarn node-test
@@ -113,6 +119,8 @@ jobs:
     steps:
       - uses: actions/checkout@v1
       - uses: actions/setup-node@v1
+        with:
+          node-version: 14
 
       - name: install deps
         run: yarn install
@@ -128,7 +136,7 @@ jobs:
   npm-smoke-tests:
     strategy:
       matrix:
-        node: ['10', '12', '14']
+        node: ['14', '16', '18']
 
     name: Smoke Tests (Node v${{ matrix.node }} with npm)
     runs-on: ubuntu-latest
@@ -154,7 +162,7 @@ jobs:
   yarn-smoke-tests:
     strategy:
       matrix:
-        node: ['10', '12', '14']
+        node: ['14', '16', '18']
 
     name: Smoke Tests (Node v${{ matrix.node }} with yarn)
     runs-on: ubuntu-latest
@@ -189,7 +197,7 @@ jobs:
       - uses: actions/checkout@v1
       - uses: actions/setup-node@v1
         with:
-          node-version: 12
+          node-version: 14
 
       - name: install deps
         run: yarn install

--- a/package.json
+++ b/package.json
@@ -60,7 +60,7 @@
     "tmp-sync": "^1.1.0"
   },
   "engines": {
-    "node": "10.* || 12.* || >= 14.*"
+    "node": "14.* || 16.* || >= 18.*"
   },
   "publishConfig": {
     "registry": "https://registry.npmjs.org"


### PR DESCRIPTION
See [Node Releases](https://github.com/nodejs/release#release-schedule)

Floating deps test is currently failing with things like

> The engine "node" is incompatible with this module. Expected version "^12.13.0 || ^14.15.0 || >=16.0.0". Got "10.24.1"

Which is to be expected for out-of-support node versions.
