### PR TITLE
Remove warning about pnpm

### DIFF
--- a/lib/utils/dependency-manager-adapter-factory.js
+++ b/lib/utils/dependency-manager-adapter-factory.js
@@ -36,10 +36,6 @@ module.exports = {
         })
       );
     } else if (config.usePnpm) {
-      console.warn(
-        'pnpm support is experimental for now. if you notice any problems please open an issue.'
-      );
-
       adapters.push(
         new PnpmAdapter({
           cwd: root,


### PR DESCRIPTION
RFC: https://github.com/emberjs/rfcs/pull/907
Implementation PR: https://github.com/ember-cli/ember-cli/pull/10287
Advancement PR: https://github.com/emberjs/rfcs/pull/932


- [x] make a repo that demonstrates that the default blueprint with pnpm passes all try scenarios
   - https://github.com/NullVoxPopuli/pnpm-default-addon-demo-ember-try-remove-pnpm-warning/actions/runs/5359698497
   

In this _more involved_ CI setup, having the default pnpm flags  https://github.com/NullVoxPopuli/ember-data-resources/actions/runs/5365368548/jobs/9734152943 and it also works
  