### PR TITLE
use --no-package-lock in npm

### DIFF
--- a/lib/dependency-manager-adapters/npm.js
+++ b/lib/dependency-manager-adapters/npm.js
@@ -133,8 +133,14 @@ module.exports = CoreObject.extend({
         if (mgrOptions.indexOf('--ignore-engines') === -1) {
           mgrOptions = mgrOptions.concat(['--ignore-engines']);
         }
-      } else if (mgrOptions.indexOf('--no-shrinkwrap') === -1) {
-        mgrOptions = mgrOptions.concat(['--no-shrinkwrap']);
+      } else if (mgrOptions.indexOf('--no-package-lock') === -1) {
+        let res = await this.run('npm', ['--version'], { cwd: this.cwd, stdio: 'pipe' });
+        let version = res.stdout;
+        if (version.match(/^4./)) {
+          mgrOptions = mgrOptions.concat(['--no-shrinkwrap']);
+        } else {
+          mgrOptions = mgrOptions.concat(['--no-package-lock']);
+        }
       }
     }
 

--- a/test/dependency-manager-adapters/npm-adapter-test.js
+++ b/test/dependency-manager-adapters/npm-adapter-test.js
@@ -81,7 +81,7 @@ describe('npmAdapter', () => {
         let stubbedRun = generateMockRun(
           [
             {
-              command: 'npm install --no-shrinkwrap',
+              command: 'npm install --no-package-lock',
               callback(command, args, opts) {
                 runCount++;
                 expect(opts).to.have.property('cwd', tmpdir);
@@ -105,7 +105,8 @@ describe('npmAdapter', () => {
         });
 
         await adapter._install();
-        expect(runCount).to.equal(2);
+        // checking for 3 commands because install checks for npm version too
+        expect(runCount).to.equal(3, 'both commands run');
       });
 
       it('runs npm prune and npm install with npm 4', async () => {
@@ -146,7 +147,8 @@ describe('npmAdapter', () => {
         });
 
         await adapter._install();
-        expect(runCount).to.equal(3, 'All three commands should run');
+        // checking for 4 commands because install checks for npm version too
+        expect(runCount).to.equal(4, 'All three commands should run');
       });
 
       it('uses managerOptions for npm commands', async () => {
@@ -155,7 +157,7 @@ describe('npmAdapter', () => {
         let stubbedRun = generateMockRun(
           [
             {
-              command: 'npm install --no-optional --no-shrinkwrap',
+              command: 'npm install --no-optional --no-package-lock',
               callback() {
                 runCount++;
                 return RSVP.resolve();
@@ -179,7 +181,8 @@ describe('npmAdapter', () => {
         });
 
         await adapter._install();
-        expect(runCount).to.equal(2);
+        // checking for 3 commands because install checks for npm version too
+        expect(runCount).to.equal(3, 'both commands run');
       });
 
       it('uses buildManagerOptions for npm commands', async () => {


### PR DESCRIPTION
This removes the warning that npm gives when you try to use the deprecated `--no-shrinkwrap` option 👍 

`--no-package-lock` was added in npm 5 so it's been recommended for a **long** time!