### PR TITLE
ember-try: Enforce resolution-mode=highest for pnpm versions 8.0.0 to 8.6.*

### DIFF
--- a/README.md
+++ b/README.md
@@ -215,6 +215,9 @@ If you include `useYarn: true` in your `ember-try` config, all npm scenarios wil
 
 If you include `usePnpm: true` in your `ember-try` config, all npm scenarios will use `pnpm` for install with the `--no-lockfile` options. At cleanup, your dependencies will be restored to their prior state.
 
+> ⚠ pnpm versions from 8.0.0 to 8.6.x have the default value of [resolution-mode](https://pnpm.io/npmrc#resolution-mode) setting changed to `lowest-direct`. This violates `ember-try` expectations as `resolution-mode` is expected to be `highest`, like in `npm` and `pnpm` versions < 8.0.0 and >= 8.7.0.
+>
+> If you run into this issue, we recommend to upgrade pnpm to latest version. If you are unable to upgrade, you can set `resolution-mode = highest` in the `.npmrc` file.
 
 ##### A note on npm scenarios with lockfiles
 

--- a/lib/dependency-manager-adapters/pnpm.js
+++ b/lib/dependency-manager-adapters/pnpm.js
@@ -5,14 +5,11 @@ const fs = require('fs-extra');
 const path = require('path');
 const debug = require('debug')('ember-try:dependency-manager-adapter:pnpm');
 const Backup = require('../utils/backup');
-const { promisify } = require('util');
-const exec = promisify(require('child_process').exec);
 const semverLt = require('semver/functions/lt');
 const semverGte = require('semver/functions/gte');
 
 const PACKAGE_JSON = 'package.json';
 const PNPM_LOCKFILE = 'pnpm-lock.yaml';
-const NPMRC_CONFIG = '.npmrc';
 
 module.exports = CoreObject.extend({
   // This still needs to be `npm` because we're still reading the dependencies
@@ -26,8 +23,8 @@ module.exports = CoreObject.extend({
   },
 
   async setup() {
+    await this._throwOnResolutionMode();
     await this.backup.addFiles([PACKAGE_JSON, PNPM_LOCKFILE]);
-    await this._updateNpmRc();
   },
 
   async changeToDependencySet(depSet) {
@@ -54,7 +51,6 @@ module.exports = CoreObject.extend({
       await this.backup.restoreFiles([PACKAGE_JSON, PNPM_LOCKFILE]);
       await this.backup.cleanUp();
       await this._install();
-      await this._revertNpmRc();
     } catch (e) {
       console.log('Error cleaning up scenario:', e); // eslint-disable-line no-console
     }
@@ -71,86 +67,45 @@ module.exports = CoreObject.extend({
 
   /**
    * pnpm versions 8.0.0 through 8.6.* have the `resolution-mode` setting inverted to
-   * `lowest-direct`, which breaks ember-try. This method conditionally adds the necessary config to
-   * .npmrc to fix this.
+   * `lowest-direct`, which breaks ember-try. This method throws a helpful error in the following
+   * case: pnpm version is within dangerous range and `pnpm config get resolution-mode` reports an
+   * empty value.
    *
-   * It covers the following cases:
-   * - pnpm version is out of dangerious range or cannot be retrieved — do not do anything
-   * - pnpm version is within dangerous range and .npmrc does not exist — create .npmrc with
-   *     `resolution-mode = highest`
-   * - pnpm version is within dangerous range and .npmrc exists — backup the .npmrc file and
-   *     append` resolution-mode = highest` to .npmrc
-   *
-   * @param {undefined | string} version — this is only used in testing. Call this fucntion without
-   *     arguments
    * @returns Promise<void>
    */
-  async _updateNpmRc(version) {
-    if (!version) {
-      version = await this._getPnpmVersion();
-    }
+  async _throwOnResolutionMode() {
+    let version = await this._getPnpmVersion();
+    let resolutionMode = await this._getResolutionMode();
 
-    if (!this._doesPnpmRequireResolutionModeFix(version)) {
-      return;
-    }
-
-    let npmrcPath = path.join(this.cwd, NPMRC_CONFIG);
-
-    if (fs.existsSync(npmrcPath)) {
-      await this.backup.addFile(NPMRC_CONFIG);
-
-      await fs.appendFileSync(npmrcPath, '\nresolution-mode = highest\n');
-    } else {
-      fs.writeFileSync(npmrcPath, 'resolution-mode = highest\n');
+    if (this._isResolutionModeWrong(version, resolutionMode)) {
+      throw new Error(
+        'You are using an old version of pnpm that uses wrong resolution mode that violates ember-try expectations. Please either upgrade pnpm or set `resolution-mode` to `highest` in `.npmrc`.'
+      );
     }
   },
 
-  /**
-   * pnpm versions 8.0.0 through 8.6.* have the `resolution-mode` setting inverted to
-   * `lowest-direct`, which breaks ember-try. This method conditionally adds the necessary config to
-   * .npmrc to fix this.
-   *
-   * It covers the following cases:
-   * - pnpm version is out of dangerious range or cannot be retrieved — do not do anything
-   * - pnpm version is within dangerous range and the backup does not exist — delete the .npmrc
-   * - pnpm version is within dangerous range and the backup exists — rename the backup to .npmrc,
-   *     overwriting the current .npmrc
-   *
-   * @param {undefined | string} version — this is only used in testing. Call this fucntion without
-   *     arguments
-   * @returns Promise<void>
-   */
-  async _revertNpmRc(version) {
-    if (!version) {
-      version = await this._getPnpmVersion();
-    }
-
-    if (!this._doesPnpmRequireResolutionModeFix(version)) {
-      return;
-    }
-
-    let npmrcPath = path.join(this.cwd, NPMRC_CONFIG);
-
-    if (this.backup.hasFile(NPMRC_CONFIG)) {
-      await this.backup.restoreFile(NPMRC_CONFIG);
-    } else {
-      if (fs.existsSync(npmrcPath)) {
-        fs.removeSync(npmrcPath);
-      }
-    }
+  async _getPnpmVersion() {
+    let result = await this.run('pnpm', ['--version'], { cwd: this.cwd, stdio: 'pipe' });
+    return result.stdout.split('\n')[0];
   },
 
-  async _getPnpmVersion(command = 'pnpm --version') {
-    try {
-      let result = await exec(command);
-      return result.stdout.split('\n')[0];
-    } catch (error) {
-      return null;
-    }
+  async _getResolutionMode() {
+    let result = await this.run('pnpm', ['config', 'get', 'resolution-mode'], {
+      cwd: this.cwd,
+      stdio: 'pipe',
+    });
+
+    return result.stdout.split('\n')[0];
   },
 
-  _doesPnpmRequireResolutionModeFix(versionStr) {
-    return versionStr ? semverGte(versionStr, '8.0.0') && semverLt(versionStr, '8.7.0') : false;
+  _isResolutionModeWrong(versionStr, resolutionMode) {
+    // The `resolution-mode` is not set explicitly, and the current pnpm version makes it default
+    // to `lowest-direct`
+    if (!resolutionMode.length && semverGte(versionStr, '8.0.0') && semverLt(versionStr, '8.7.0')) {
+      return true;
+    }
+
+    return false;
   },
 
   async _install(depSet) {

--- a/lib/dependency-manager-adapters/pnpm.js
+++ b/lib/dependency-manager-adapters/pnpm.js
@@ -5,9 +5,14 @@ const fs = require('fs-extra');
 const path = require('path');
 const debug = require('debug')('ember-try:dependency-manager-adapter:pnpm');
 const Backup = require('../utils/backup');
+const { promisify } = require('util');
+const exec = promisify(require('child_process').exec);
+const semverLt = require('semver/functions/lt');
+const semverGte = require('semver/functions/gte');
 
 const PACKAGE_JSON = 'package.json';
 const PNPM_LOCKFILE = 'pnpm-lock.yaml';
+const NPMRC_CONFIG = '.npmrc';
 
 module.exports = CoreObject.extend({
   // This still needs to be `npm` because we're still reading the dependencies
@@ -22,11 +27,11 @@ module.exports = CoreObject.extend({
 
   async setup() {
     await this.backup.addFiles([PACKAGE_JSON, PNPM_LOCKFILE]);
+    await this._updateNpmRc();
   },
 
   async changeToDependencySet(depSet) {
     await this.applyDependencySet(depSet);
-
     await this._install(depSet);
 
     let deps = Object.assign({}, depSet.dependencies, depSet.devDependencies);
@@ -49,6 +54,7 @@ module.exports = CoreObject.extend({
       await this.backup.restoreFiles([PACKAGE_JSON, PNPM_LOCKFILE]);
       await this.backup.cleanUp();
       await this._install();
+      await this._revertNpmRc();
     } catch (e) {
       console.log('Error cleaning up scenario:', e); // eslint-disable-line no-console
     }
@@ -61,6 +67,90 @@ module.exports = CoreObject.extend({
     } else {
       return null;
     }
+  },
+
+  /**
+   * pnpm versions 8.0.0 through 8.6.* have the `resolution-mode` setting inverted to
+   * `lowest-direct`, which breaks ember-try. This method conditionally adds the necessary config to
+   * .npmrc to fix this.
+   *
+   * It covers the following cases:
+   * - pnpm version is out of dangerious range or cannot be retrieved — do not do anything
+   * - pnpm version is within dangerous range and .npmrc does not exist — create .npmrc with
+   *     `resolution-mode = highest`
+   * - pnpm version is within dangerous range and .npmrc exists — backup the .npmrc file and
+   *     append` resolution-mode = highest` to .npmrc
+   *
+   * @param {undefined | string} version — this is only used in testing. Call this fucntion without
+   *     arguments
+   * @returns Promise<void>
+   */
+  async _updateNpmRc(version) {
+    if (!version) {
+      version = await this._getPnpmVersion();
+    }
+
+    if (!this._doesPnpmRequireResolutionModeFix(version)) {
+      return;
+    }
+
+    let npmrcPath = path.join(this.cwd, NPMRC_CONFIG);
+
+    if (fs.existsSync(npmrcPath)) {
+      await this.backup.addFile(NPMRC_CONFIG);
+
+      await fs.appendFileSync(npmrcPath, '\nresolution-mode = highest\n');
+    } else {
+      fs.writeFileSync(npmrcPath, 'resolution-mode = highest\n');
+    }
+  },
+
+  /**
+   * pnpm versions 8.0.0 through 8.6.* have the `resolution-mode` setting inverted to
+   * `lowest-direct`, which breaks ember-try. This method conditionally adds the necessary config to
+   * .npmrc to fix this.
+   *
+   * It covers the following cases:
+   * - pnpm version is out of dangerious range or cannot be retrieved — do not do anything
+   * - pnpm version is within dangerous range and the backup does not exist — delete the .npmrc
+   * - pnpm version is within dangerous range and the backup exists — rename the backup to .npmrc,
+   *     overwriting the current .npmrc
+   *
+   * @param {undefined | string} version — this is only used in testing. Call this fucntion without
+   *     arguments
+   * @returns Promise<void>
+   */
+  async _revertNpmRc(version) {
+    if (!version) {
+      version = await this._getPnpmVersion();
+    }
+
+    if (!this._doesPnpmRequireResolutionModeFix(version)) {
+      return;
+    }
+
+    let npmrcPath = path.join(this.cwd, NPMRC_CONFIG);
+
+    if (this.backup.hasFile(NPMRC_CONFIG)) {
+      await this.backup.restoreFile(NPMRC_CONFIG);
+    } else {
+      if (fs.existsSync(npmrcPath)) {
+        fs.removeSync(npmrcPath);
+      }
+    }
+  },
+
+  async _getPnpmVersion(command = 'pnpm --version') {
+    try {
+      let result = await exec(command);
+      return result.stdout.split('\n')[0];
+    } catch (error) {
+      return null;
+    }
+  },
+
+  _doesPnpmRequireResolutionModeFix(versionStr) {
+    return versionStr ? semverGte(versionStr, '8.0.0') && semverLt(versionStr, '8.7.0') : false;
   },
 
   async _install(depSet) {

--- a/lib/utils/backup.js
+++ b/lib/utils/backup.js
@@ -1,7 +1,7 @@
 'use strict';
 
 const debug = require('debug')('ember-try:backup');
-const { copy, existsSync, mkdirSync } = require('fs-extra');
+const { copy, existsSync } = require('fs-extra');
 const { createHash } = require('node:crypto');
 const { join } = require('node:path');
 const { promisify } = require('node:util');
@@ -12,7 +12,6 @@ module.exports = class Backup {
   constructor({ cwd }) {
     this.cwd = cwd;
     this.dir = join(tempDir, 'ember-try', createHash('sha256').update(cwd).digest('hex'));
-    mkdirSync(this.dir, { recursive: true });
 
     debug(`Created backup directory ${this.dir}`);
   }
@@ -92,17 +91,5 @@ module.exports = class Backup {
    */
   restoreFiles(filenames) {
     return Promise.all(filenames.map((filename) => this.restoreFile(filename)));
-  }
-
-  /**
-   * Checks if a file exists in the backup directory.
-   *
-   * @param {String} filename Filename relative to the current working directory.
-   * @returns {boolean}
-   */
-  hasFile(filename) {
-    let backupFile = this.pathForFile(filename);
-
-    return existsSync(backupFile);
   }
 };

--- a/lib/utils/backup.js
+++ b/lib/utils/backup.js
@@ -1,7 +1,7 @@
 'use strict';
 
 const debug = require('debug')('ember-try:backup');
-const { copy, existsSync } = require('fs-extra');
+const { copy, existsSync, mkdirSync } = require('fs-extra');
 const { createHash } = require('node:crypto');
 const { join } = require('node:path');
 const { promisify } = require('node:util');
@@ -12,6 +12,7 @@ module.exports = class Backup {
   constructor({ cwd }) {
     this.cwd = cwd;
     this.dir = join(tempDir, 'ember-try', createHash('sha256').update(cwd).digest('hex'));
+    mkdirSync(this.dir, { recursive: true });
 
     debug(`Created backup directory ${this.dir}`);
   }
@@ -91,5 +92,17 @@ module.exports = class Backup {
    */
   restoreFiles(filenames) {
     return Promise.all(filenames.map((filename) => this.restoreFile(filename)));
+  }
+
+  /**
+   * Checks if a file exists in the backup directory.
+   *
+   * @param {String} filename Filename relative to the current working directory.
+   * @returns {boolean}
+   */
+  hasFile(filename) {
+    let backupFile = this.pathForFile(filename);
+
+    return existsSync(backupFile);
   }
 };

--- a/package.json
+++ b/package.json
@@ -59,6 +59,7 @@
     "release-it": "^14.11.6",
     "release-it-lerna-changelog": "^3.1.0",
     "rsvp": "^4.7.0",
+    "sinon": "^15.2.0",
     "tmp-sync": "^1.1.0"
   },
   "engines": {

--- a/package.json
+++ b/package.json
@@ -44,6 +44,7 @@
   },
   "devDependencies": {
     "chai": "^4.3.4",
+    "chai-as-promised": "^7.1.1",
     "codecov": "^3.8.3",
     "ember-cli": "~3.22.0",
     "eslint": "^7.31.0",

--- a/test/dependency-manager-adapters/pnpm-adapter-test.js
+++ b/test/dependency-manager-adapters/pnpm-adapter-test.js
@@ -1,6 +1,9 @@
 'use strict';
 
-let expect = require('chai').expect;
+let chai = require('chai');
+let chaiAsPromised = require('chai-as-promised');
+chai.use(chaiAsPromised);
+let { expect } = chai;
 let fs = require('fs-extra');
 let path = require('path');
 let tmp = require('tmp-sync');
@@ -11,6 +14,15 @@ let generateMockRun = require('../helpers/generate-mock-run');
 let root = process.cwd();
 let tmproot = path.join(root, 'tmp');
 let tmpdir;
+
+function setResolutionModeToHighest(dir) {
+  // package.json is required for `pnpm config get` to work
+  let packageJsonPath = path.join(dir, 'package.json');
+  fs.writeFileSync(packageJsonPath, '{"private": true}');
+
+  let npmrcPath = path.join(dir, '.npmrc');
+  fs.writeFileSync(npmrcPath, 'resolution-mode = highest');
+}
 
 describe('pnpm Adapter', () => {
   beforeEach(() => {
@@ -25,11 +37,33 @@ describe('pnpm Adapter', () => {
   });
 
   describe('#setup', () => {
+    beforeEach(() => {
+      setResolutionModeToHighest(tmpdir);
+    });
+
     it('backs up the `package.json` and `pnpm-lock.yaml` files', async () => {
       await fs.outputJson('package.json', { originalPackageJSON: true });
       await fs.outputFile('pnpm-lock.yaml', 'originalYAML: true\n');
 
-      let adapter = new PnpmAdapter({ cwd: tmpdir });
+      let stubbedRun = generateMockRun(
+        [
+          {
+            command: 'pnpm --version',
+            async callback(/* command, args, opts */) {
+              return { stdout: '9.0.0\n' };
+            },
+          },
+          {
+            command: 'pnpm config get resolution-mode',
+            async callback(/* command, args, opts */) {
+              return { stdout: 'highest\n' };
+            },
+          },
+        ],
+        { allowPassthrough: false }
+      );
+
+      let adapter = new PnpmAdapter({ cwd: tmpdir, run: stubbedRun });
       await adapter.setup();
 
       expect(await fs.readJson(adapter.backup.pathForFile('package.json'))).to.deep.equal({
@@ -43,7 +77,25 @@ describe('pnpm Adapter', () => {
     it('ignores missing `pnpm-lock.yaml` files', async () => {
       await fs.outputJson('package.json', { originalPackageJSON: true });
 
-      let adapter = new PnpmAdapter({ cwd: tmpdir });
+      let stubbedRun = generateMockRun(
+        [
+          {
+            command: 'pnpm --version',
+            async callback(/* command, args, opts */) {
+              return { stdout: '9.0.0\n' };
+            },
+          },
+          {
+            command: 'pnpm config get resolution-mode',
+            async callback(/* command, args, opts */) {
+              return { stdout: 'highest\n' };
+            },
+          },
+        ],
+        { allowPassthrough: false }
+      );
+
+      let adapter = new PnpmAdapter({ cwd: tmpdir, run: stubbedRun });
       await adapter.setup();
 
       expect(await fs.readJson(adapter.backup.pathForFile('package.json'))).to.deep.equal({
@@ -54,6 +106,10 @@ describe('pnpm Adapter', () => {
   });
 
   describe('#changeToDependencySet', () => {
+    beforeEach(() => {
+      setResolutionModeToHighest(tmpdir);
+    });
+
     it('updates the `package.json` and runs `pnpm install`', async () => {
       await fs.outputJson('package.json', {
         devDependencies: {
@@ -69,6 +125,18 @@ describe('pnpm Adapter', () => {
             async callback(command, args, opts) {
               runCount++;
               expect(opts).to.have.property('cwd', tmpdir);
+            },
+          },
+          {
+            command: 'pnpm --version',
+            async callback(/* command, args, opts */) {
+              return { stdout: '9.0.0\n' };
+            },
+          },
+          {
+            command: 'pnpm config get resolution-mode',
+            async callback(/* command, args, opts */) {
+              return { stdout: 'highest\n' };
             },
           },
         ],
@@ -111,7 +179,7 @@ describe('pnpm Adapter', () => {
       expect(runCount).to.equal(1);
     });
 
-    it('runs _updateNpmRc before _install', async () => {
+    it('runs _throwOnResolutionMode before _install', async () => {
       await fs.outputJson('package.json', {
         devDependencies: {
           'ember-try-test-suite-helper': '0.1.0',
@@ -124,7 +192,7 @@ describe('pnpm Adapter', () => {
 
       const updateStub = sinon.replace(
         adapter,
-        '_updateNpmRc',
+        '_throwOnResolutionMode',
         sinon.fake(() => {})
       );
 
@@ -146,6 +214,10 @@ describe('pnpm Adapter', () => {
   });
 
   describe('#cleanup', () => {
+    beforeEach(() => {
+      setResolutionModeToHighest(tmpdir);
+    });
+
     it('restores the `package.json` and `pnpm-lock.yaml` files, and then runs `pnpm install`', async () => {
       await fs.outputJson('package.json', { originalPackageJSON: true });
       await fs.outputFile('pnpm-lock.yaml', 'originalYAML: true\n');
@@ -158,6 +230,18 @@ describe('pnpm Adapter', () => {
             async callback(command, args, opts) {
               runCount++;
               expect(opts).to.have.property('cwd', tmpdir);
+            },
+          },
+          {
+            command: 'pnpm --version',
+            async callback(/* command, args, opts */) {
+              return { stdout: '9.0.0\n' };
+            },
+          },
+          {
+            command: 'pnpm config get resolution-mode',
+            async callback(/* command, args, opts */) {
+              return { stdout: 'highest\n' };
             },
           },
         ],
@@ -181,33 +265,6 @@ describe('pnpm Adapter', () => {
       expect(await fs.readFile('pnpm-lock.yaml', 'utf-8')).to.equal('originalYAML: true\n');
 
       expect(runCount).to.equal(1);
-    });
-
-    it('runs _revertNpmRc after _install', async () => {
-      await fs.outputJson('package.json', { modifiedPackageJSON: true });
-      await fs.outputJson('package.json.ember-try', { originalPackageJSON: true });
-      await fs.outputFile('pnpm-lock.yaml', 'modifiedYAML: true\n');
-      await fs.outputFile('pnpm-lock.ember-try.yaml', 'originalYAML: true\n');
-
-      let adapter = new PnpmAdapter({
-        cwd: tmpdir,
-      });
-
-      const revertStub = sinon.replace(
-        adapter,
-        '_revertNpmRc',
-        sinon.fake(() => {})
-      );
-
-      const installStub = sinon.replace(
-        adapter,
-        '_install',
-        sinon.fake(() => {})
-      );
-
-      await adapter.cleanup();
-
-      expect(revertStub.calledAfter(installStub)).to.be.true;
     });
   });
 
@@ -393,21 +450,37 @@ describe('pnpm Adapter', () => {
     });
   });
 
-  describe('#_doesPnpmRequireResolutionModeFix', () => {
+  describe('#_isResolutionModeWrong', () => {
     [
-      { given: null, expected: false },
-      { given: '1.0.0', expected: false },
-      { given: '7.9.9999', expected: false },
-      { given: '8.0.0', expected: true },
-      { given: '8.1.2', expected: true },
-      { given: '8.6.9999', expected: true },
-      { given: '8.7.0', expected: false },
-      { given: '8.7.1', expected: false },
-      { given: '9.0.0', expected: false },
-    ].forEach(({ given, expected }) => {
-      it(`works with given version "${given}"`, () => {
+      { expected: false, pnpmVersion: '1.0.0', resolutionMode: '' },
+      { expected: false, pnpmVersion: '7.9.9999', resolutionMode: '' },
+      { expected: true, pnpmVersion: '8.0.0', resolutionMode: '' },
+      { expected: true, pnpmVersion: '8.1.2', resolutionMode: '' },
+      { expected: true, pnpmVersion: '8.6.9999', resolutionMode: '' },
+      { expected: false, pnpmVersion: '8.7.0', resolutionMode: '' },
+      { expected: false, pnpmVersion: '8.7.1', resolutionMode: '' },
+      { expected: false, pnpmVersion: '9.0.0', resolutionMode: '' },
+      { expected: false, pnpmVersion: '1.0.0', resolutionMode: 'highest' },
+      { expected: false, pnpmVersion: '7.9.9999', resolutionMode: 'highest' },
+      { expected: false, pnpmVersion: '8.0.0', resolutionMode: 'highest' },
+      { expected: false, pnpmVersion: '8.1.2', resolutionMode: 'highest' },
+      { expected: false, pnpmVersion: '8.6.9999', resolutionMode: 'highest' },
+      { expected: false, pnpmVersion: '8.7.0', resolutionMode: 'highest' },
+      { expected: false, pnpmVersion: '8.7.1', resolutionMode: 'highest' },
+      { expected: false, pnpmVersion: '9.0.0', resolutionMode: 'highest' },
+      { expected: false, pnpmVersion: '1.0.0', resolutionMode: 'lowest-direct' },
+      { expected: false, pnpmVersion: '7.9.9999', resolutionMode: 'lowest-direct' },
+      { expected: false, pnpmVersion: '8.0.0', resolutionMode: 'lowest-direct' },
+      { expected: false, pnpmVersion: '8.1.2', resolutionMode: 'lowest-direct' },
+      { expected: false, pnpmVersion: '8.6.9999', resolutionMode: 'lowest-direct' },
+      { expected: false, pnpmVersion: '8.7.0', resolutionMode: 'lowest-direct' },
+      { expected: false, pnpmVersion: '8.7.1', resolutionMode: 'lowest-direct' },
+      { expected: false, pnpmVersion: '9.0.0', resolutionMode: 'lowest-direct' },
+    ].forEach(({ pnpmVersion, resolutionMode, expected }) => {
+      it(`works with given version "${pnpmVersion}" and resolutionMode "${resolutionMode}"`, () => {
         let npmAdapter = new PnpmAdapter({ cwd: tmpdir });
-        let result = npmAdapter._doesPnpmRequireResolutionModeFix(given);
+
+        let result = npmAdapter._isResolutionModeWrong(pnpmVersion, resolutionMode);
         expect(result).equal(expected);
       });
     });
@@ -421,111 +494,145 @@ describe('pnpm Adapter', () => {
       { version: 'how the turntables' },
     ].forEach(({ version }) => {
       it(`works with given version "${version}"`, async () => {
-        let npmAdapter = new PnpmAdapter({ cwd: tmpdir });
-        let result = await npmAdapter._getPnpmVersion(`echo ${version}`);
+        let stubbedRun = generateMockRun(
+          [
+            {
+              command: 'pnpm --version',
+              async callback(/* command, args, opts */) {
+                return {  stdout: `${version}\n` };
+              },
+            },
+          ],
+          { allowPassthrough: false }
+        );
+
+        let npmAdapter = new PnpmAdapter({ cwd: tmpdir, run: stubbedRun });
+        let result = await npmAdapter._getPnpmVersion();
         expect(result).equal(version);
       });
     });
   });
 
-  describe('#_updateNpmRc', () => {
-    describe('when pnpm version requires the resolution-mode fix', () => {
-      it(`should create a new .npmrc file when none exists`, async () => {
-        let npmAdapter = new PnpmAdapter({ cwd: tmpdir });
-        let npmrcPath = path.join(tmpdir, '.npmrc');
-        let npmrcBackupPath = path.join(tmpdir, '.npmrc.ember-try');
+  describe('#_getResolutionMode', () => {
+    it('when no .npmrc is present, it should return an empty string', async () => {
+      let stubbedRun = generateMockRun(
+        [
+          {
+            command: 'pnpm config get resolution-mode',
+            async callback(/* command, args, opts */) {
+              return { stdout: '' };
+            },
+          },
+        ],
+        { allowPassthrough: false }
+      );
 
-        await npmAdapter._updateNpmRc('8.6.0');
+      let npmAdapter = new PnpmAdapter({ cwd: tmpdir, run: stubbedRun });
 
-        let actualFileContent = fs.readFileSync(npmrcPath, 'utf8');
-        let expectedFileContent = 'resolution-mode = highest\n';
-
-        expect(actualFileContent, '.npmrc content').to.equal(expectedFileContent);
-        expect(fs.existsSync(npmrcBackupPath), '.npmrc.ember-try does not exist').to.be.false;
-      });
-
-      it(`should update an npmrc file when it already exists`, async () => {
-        let npmAdapter = new PnpmAdapter({ cwd: tmpdir });
-        let npmrcPath = path.join(tmpdir, '.npmrc');
-        let npmrcBackupPath = npmAdapter.backup.pathForFile('.npmrc');
-
-        fs.writeFileSync(npmrcPath, 'foo = bar\n');
-
-        await npmAdapter._updateNpmRc('8.6.0');
-
-        let actualFileContent = fs.readFileSync(npmrcPath, 'utf8');
-        let expectedFileContent = 'foo = bar\n\nresolution-mode = highest\n';
-        expect(actualFileContent, '.npmrc content').to.equal(expectedFileContent);
-
-        let actualBackupFileContent = fs.readFileSync(npmrcBackupPath, 'utf8');
-        let expectedBackupFileContent = 'foo = bar\n';
-        expect(actualBackupFileContent, '.npmrc-backup content').to.equal(
-          expectedBackupFileContent
-        );
-      });
+      let result = await npmAdapter._getResolutionMode();
+      expect(result).equal('');
     });
 
-    describe('when pnpm version does not the resolution-mode fix', () => {
-      it(`should not create a new .npmrc file`, async () => {
-        let npmAdapter = new PnpmAdapter({ cwd: tmpdir });
-        let npmrcPath = path.join(tmpdir, '.npmrc');
-        let npmrcBackupPath = path.join(tmpdir, '.npmrc.ember-try');
+    it('when .npmrc contains reslution-mode, it should return the given resolution mode', async () => {
+      let stubbedRun = generateMockRun(
+        [
+          {
+            command: 'pnpm config get resolution-mode',
+            async callback(/* command, args, opts */) {
+              return { stdout: 'highest\n' };
+            },
+          },
+        ],
+        { allowPassthrough: false }
+      );
 
-        await npmAdapter._updateNpmRc('7.6.0');
+      let npmAdapter = new PnpmAdapter({ cwd: tmpdir, run: stubbedRun });
 
-        expect(fs.existsSync(npmrcPath), '.npmrc does not exist').to.be.false;
-        expect(fs.existsSync(npmrcBackupPath), '.npmrc.ember-try does not exist').to.be.false;
-      });
+      setResolutionModeToHighest(tmpdir);
+
+      let result = await npmAdapter._getResolutionMode();
+      expect(result).equal('highest');
     });
   });
 
-  describe('#_revertNpmRc', () => {
+  describe('#_throwOnResolutionMode', () => {
     describe('when pnpm version requires the resolution-mode fix', () => {
-      it(`when backup does not exist, it should delete the .npmrc file`, async () => {
-        let npmAdapter = new PnpmAdapter({ cwd: tmpdir });
-        let npmrcPath = path.join(tmpdir, '.npmrc');
-        let npmrcBackupPath = path.join(tmpdir, '.npmrc.ember-try');
+      it(`when resoultion-mode is not highest, should throw an error`, async () => {
+        let stubbedRun = generateMockRun(
+          [
+            {
+              command: 'pnpm --version',
+              async callback(/* command, args, opts */) {
+                return { stdout: '8.6.0\n' };
+              },
+            },
+            {
+              command: 'pnpm config get resolution-mode',
+              async callback(/* command, args, opts */) {
+                return { stdout: '' };
+              },
+            },
+          ],
+          { allowPassthrough: false }
+        );
 
-        fs.writeFileSync(npmrcPath, 'resolution-mode = highest\n');
+        let npmAdapter = new PnpmAdapter({ cwd: tmpdir, run: stubbedRun });
 
-        await npmAdapter._revertNpmRc('8.6.0');
-
-        expect(fs.existsSync(npmrcPath), '.npmrc.ember-try does not exist').to.be.false;
-        expect(fs.existsSync(npmrcBackupPath), '.npmrc.ember-try does not exist').to.be.false;
+        return expect(npmAdapter._throwOnResolutionMode()).to.eventually.be.rejectedWith(
+          'You are using an old version of pnpm that uses wrong resolution mode that violates ember-try expectations. Please either upgrade pnpm or set `resolution-mode` to `highest` in `.npmrc`.'
+        );
       });
 
-      it(`when backup exists, it should replace the original file with backup and delete the backup`, async () => {
-        let npmAdapter = new PnpmAdapter({ cwd: tmpdir });
-        let npmrcPath = path.join(tmpdir, '.npmrc');
-        let npmrcBackupPath = npmAdapter.backup.pathForFile('.npmrc');
+      it(`when resoultion-mode is highest, should not throw an error`, async () => {
+        let stubbedRun = generateMockRun(
+          [
+            {
+              command: 'pnpm --version',
+              async callback(/* command, args, opts */) {
+                return { stdout: '8.6.0\n' };
+              },
+            },
+            {
+              command: 'pnpm config get resolution-mode',
+              async callback(/* command, args, opts */) {
+                return { stdout: 'highest\n' };
+              },
+            },
+          ],
+          { allowPassthrough: false }
+        );
 
-        fs.writeFileSync(npmrcPath, 'foo = bar\n\nresolution-mode = highest\n');
-        fs.writeFileSync(npmrcBackupPath, 'foo = bar\n');
+        let npmAdapter = new PnpmAdapter({ cwd: tmpdir, run: stubbedRun });
 
-        await npmAdapter._revertNpmRc('8.6.0');
+        setResolutionModeToHighest(tmpdir);
 
-        let actualFileContent = fs.readFileSync(npmrcPath, 'utf8');
-        let expectedFileContent = 'foo = bar\n';
-
-        expect(actualFileContent, '.npmrc content').to.equal(expectedFileContent);
-        // expect(fs.existsSync(npmrcBackupPath), '.npmrc.ember-try existence').to.be.false;
+        await npmAdapter._throwOnResolutionMode('8.6.0');
       });
     });
 
     describe('when pnpm version does not the resolution-mode fix', () => {
-      it(`should not touch the existing .npmrc file`, async () => {
-        let npmAdapter = new PnpmAdapter({ cwd: tmpdir });
-        let npmrcPath = path.join(tmpdir, '.npmrc');
-        let npmrcBackupPath = path.join(tmpdir, '.npmrc.ember-try');
+      it(`should not throw an error`, async () => {
+        let stubbedRun = generateMockRun(
+          [
+            {
+              command: 'pnpm --version',
+              async callback(/* command, args, opts */) {
+                return { stdout: '7.6.0\n' };
+              },
+            },
+            {
+              command: 'pnpm config get resolution-mode',
+              async callback(/* command, args, opts */) {
+                return { stdout: 'highest\n' };
+              },
+            },
+          ],
+          { allowPassthrough: false }
+        );
 
-        fs.writeFileSync(npmrcPath, 'foo = bar\n');
+        let npmAdapter = new PnpmAdapter({ cwd: tmpdir, run: stubbedRun });
 
-        await npmAdapter._revertNpmRc('7.6.0');
-
-        let actualFileContent = fs.readFileSync(npmrcPath, 'utf8');
-
-        expect(actualFileContent, '.npmrc content').to.equal('foo = bar\n');
-        expect(fs.existsSync(npmrcBackupPath), '.npmrc.ember-try does not exist').to.be.false;
+        await npmAdapter._throwOnResolutionMode();
       });
     });
   });

--- a/yarn.lock
+++ b/yarn.lock
@@ -415,6 +415,41 @@
   resolved "https://registry.yarnpkg.com/@sindresorhus/is/-/is-4.0.0.tgz#2ff674e9611b45b528896d820d3d7a812de2f0e4"
   integrity sha512-FyD2meJpDPjyNQejSjvnhpgI/azsQkA4lGbuu5BQZfjvJ9cbRZXzeWL2HceCekW4lixO9JPesIIQkSoLjeJHNQ==
 
+"@sinonjs/commons@^2.0.0":
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/@sinonjs/commons/-/commons-2.0.0.tgz#fd4ca5b063554307e8327b4564bd56d3b73924a3"
+  integrity sha512-uLa0j859mMrg2slwQYdO/AkrOfmH+X6LTVmNTS9CqexuE2IvVORIkSpJLqePAbEnKJ77aMmCwr1NUZ57120Xcg==
+  dependencies:
+    type-detect "4.0.8"
+
+"@sinonjs/commons@^3.0.0":
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/@sinonjs/commons/-/commons-3.0.0.tgz#beb434fe875d965265e04722ccfc21df7f755d72"
+  integrity sha512-jXBtWAF4vmdNmZgD5FoKsVLv3rPgDnLgPbU84LIJ3otV44vJlDRokVng5v8NFJdCf/da9legHcKaRuZs4L7faA==
+  dependencies:
+    type-detect "4.0.8"
+
+"@sinonjs/fake-timers@^10.0.2", "@sinonjs/fake-timers@^10.3.0":
+  version "10.3.0"
+  resolved "https://registry.yarnpkg.com/@sinonjs/fake-timers/-/fake-timers-10.3.0.tgz#55fdff1ecab9f354019129daf4df0dd4d923ea66"
+  integrity sha512-V4BG07kuYSUkTCSBHG8G8TNhM+F19jXFWnQtzj+we8DrkpSBCee9Z3Ms8yiGer/dlmhe35/Xdgyo3/0rQKg7YA==
+  dependencies:
+    "@sinonjs/commons" "^3.0.0"
+
+"@sinonjs/samsam@^8.0.0":
+  version "8.0.0"
+  resolved "https://registry.yarnpkg.com/@sinonjs/samsam/-/samsam-8.0.0.tgz#0d488c91efb3fa1442e26abea81759dfc8b5ac60"
+  integrity sha512-Bp8KUVlLp8ibJZrnvq2foVhP0IVX2CIprMJPK0vqGqgrDa0OHVKeZyBykqskkrdxV6yKBPmGasO8LVjAKR3Gew==
+  dependencies:
+    "@sinonjs/commons" "^2.0.0"
+    lodash.get "^4.4.2"
+    type-detect "^4.0.8"
+
+"@sinonjs/text-encoding@^0.7.1":
+  version "0.7.2"
+  resolved "https://registry.yarnpkg.com/@sinonjs/text-encoding/-/text-encoding-0.7.2.tgz#5981a8db18b56ba38ef0efb7d995b12aa7b51918"
+  integrity sha512-sXXKG+uL9IrKqViTtao2Ws6dy0znu9sOaP1di/jKGW1M6VssO8vlpXCQcpZ+jisQ1tTFAC5Jo/EOzFbggBagFQ==
+
 "@szmarczak/http-timer@^1.1.2":
   version "1.1.2"
   resolved "https://registry.yarnpkg.com/@szmarczak/http-timer/-/http-timer-1.1.2.tgz#b1665e2c461a2cd92f4c1bbf50d5454de0d4b421"
@@ -2431,6 +2466,11 @@ diff@4.0.2, diff@^4.0.2:
   version "4.0.2"
   resolved "https://registry.yarnpkg.com/diff/-/diff-4.0.2.tgz#60f3aecb89d5fae520c11aa19efc2bb982aade7d"
   integrity sha512-58lmxKSA4BNyLz+HHMUzlOEpg09FV+ev6ZMe3vJihgdxzgcwZ8VoEEPmALCZG9LmqfVoNMMKpttIYTVG6uDY7A==
+
+diff@^5.1.0:
+  version "5.1.0"
+  resolved "https://registry.yarnpkg.com/diff/-/diff-5.1.0.tgz#bc52d298c5ea8df9194800224445ed43ffc87e40"
+  integrity sha512-D+mk+qE8VC/PAUrlAU34N+VfXev0ghe5ywmpqrawphmVZc1bEfn56uo9qpyGp1p4xpzOHkSW4ztBd6L7Xx4ACw==
 
 dir-glob@^3.0.1:
   version "3.0.1"
@@ -4931,6 +4971,11 @@ jsonify@~0.0.0:
   resolved "https://registry.yarnpkg.com/jsonify/-/jsonify-0.0.0.tgz#2c74b6ee41d93ca51b7b5aaee8f503631d252a73"
   integrity sha1-LHS27kHZPKUbe1qu6PUDYx0lKnM=
 
+just-extend@^4.0.2:
+  version "4.2.1"
+  resolved "https://registry.yarnpkg.com/just-extend/-/just-extend-4.2.1.tgz#ef5e589afb61e5d66b24eca749409a8939a8c744"
+  integrity sha512-g3UB796vUFIY90VIv/WX3L2c8CS2MdWUww3CNrYmqza1Fg0DURc2K/O4YrnklBdQarSJ/y8JnJYDGc+1iumQjg==
+
 keyv@3.0.0:
   version "3.0.0"
   resolved "https://registry.yarnpkg.com/keyv/-/keyv-3.0.0.tgz#44923ba39e68b12a7cec7df6c3268c031f2ef373"
@@ -5163,6 +5208,11 @@ lodash.foreach@^4.5.0:
   version "4.5.0"
   resolved "https://registry.yarnpkg.com/lodash.foreach/-/lodash.foreach-4.5.0.tgz#1a6a35eace401280c7f06dddec35165ab27e3e53"
   integrity sha1-Gmo16s5AEoDH8G3d7DUWWrJ+PlM=
+
+lodash.get@^4.4.2:
+  version "4.4.2"
+  resolved "https://registry.yarnpkg.com/lodash.get/-/lodash.get-4.4.2.tgz#2d177f652fa31e939b4438d5341499dfa3825e99"
+  integrity sha512-z+Uw/vLuy6gQe8cfaFWD7p0wVv8fJl3mbzXh33RS+0oW2wvUqiRXiQ69gLWSLpgB5/6sU+r6BlQR0MBILadqTQ==
 
 lodash.isarguments@^3.0.0:
   version "3.1.0"
@@ -5777,6 +5827,17 @@ nice-try@^1.0.4:
   resolved "https://registry.yarnpkg.com/nice-try/-/nice-try-1.0.5.tgz#a3378a7696ce7d223e88fc9b764bd7ef1089e366"
   integrity sha512-1nh45deeb5olNY7eX82BkPO7SSxR5SSYJiPTrTdFUVYwAl8CKMA5N9PjTYkHiRjisVcxcQ1HXdLhx2qxxJzLNQ==
 
+nise@^5.1.4:
+  version "5.1.4"
+  resolved "https://registry.yarnpkg.com/nise/-/nise-5.1.4.tgz#491ce7e7307d4ec546f5a659b2efe94a18b4bbc0"
+  integrity sha512-8+Ib8rRJ4L0o3kfmyVCL7gzrohyDe0cMFTBa2d364yIrEGMEoetznKJx899YxjybU6bL9SQkYPSBBs1gyYs8Xg==
+  dependencies:
+    "@sinonjs/commons" "^2.0.0"
+    "@sinonjs/fake-timers" "^10.0.2"
+    "@sinonjs/text-encoding" "^0.7.1"
+    just-extend "^4.0.2"
+    path-to-regexp "^1.7.0"
+
 node-fetch@^2.6.0, node-fetch@^2.6.1:
   version "2.6.1"
   resolved "https://registry.yarnpkg.com/node-fetch/-/node-fetch-2.6.1.tgz#045bd323631f76ed2e2b55573394416b639a0052"
@@ -6348,6 +6409,13 @@ path-to-regexp@0.1.7:
   version "0.1.7"
   resolved "https://registry.yarnpkg.com/path-to-regexp/-/path-to-regexp-0.1.7.tgz#df604178005f522f15eb4490e7247a1bfaa67f8c"
   integrity sha1-32BBeABfUi8V60SQ5yR6G/qmf4w=
+
+path-to-regexp@^1.7.0:
+  version "1.8.0"
+  resolved "https://registry.yarnpkg.com/path-to-regexp/-/path-to-regexp-1.8.0.tgz#887b3ba9d84393e87a0a0b9f4cb756198b53548a"
+  integrity sha512-n43JRhlUKUAlibEJhPeir1ncUID16QnEjNpwzNdO3Lm4ywrBpBZ5oLD0I6br9evr1Y9JTqwRtAh7JLoOzAQdVA==
+  dependencies:
+    isarray "0.0.1"
 
 path-type@^4.0.0:
   version "4.0.0"
@@ -7159,6 +7227,18 @@ silent-error@^1.0.0, silent-error@^1.0.1, silent-error@^1.1.1:
   dependencies:
     debug "^2.2.0"
 
+sinon@^15.2.0:
+  version "15.2.0"
+  resolved "https://registry.yarnpkg.com/sinon/-/sinon-15.2.0.tgz#5e44d4bc5a9b5d993871137fd3560bebfac27565"
+  integrity sha512-nPS85arNqwBXaIsFCkolHjGIkFo+Oxu9vbgmBJizLAhqe6P2o3Qmj3KCUoRkfhHtvgDhZdWD3risLHAUJ8npjw==
+  dependencies:
+    "@sinonjs/commons" "^3.0.0"
+    "@sinonjs/fake-timers" "^10.3.0"
+    "@sinonjs/samsam" "^8.0.0"
+    diff "^5.1.0"
+    nise "^5.1.4"
+    supports-color "^7.2.0"
+
 slash@^3.0.0:
   version "3.0.0"
   resolved "https://registry.yarnpkg.com/slash/-/slash-3.0.0.tgz#6539be870c165adbd5240220dbe361f1bc4d4634"
@@ -7595,7 +7675,7 @@ sum-up@^1.0.1:
   dependencies:
     chalk "^1.0.0"
 
-supports-color@7.2.0, supports-color@^7.1.0:
+supports-color@7.2.0, supports-color@^7.1.0, supports-color@^7.2.0:
   version "7.2.0"
   resolved "https://registry.yarnpkg.com/supports-color/-/supports-color-7.2.0.tgz#1b7dcdcb32b8138801b3e478ba6a51caa89648da"
   integrity sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==
@@ -7916,7 +7996,7 @@ type-check@^0.4.0, type-check@~0.4.0:
   dependencies:
     prelude-ls "^1.2.1"
 
-type-detect@^4.0.0, type-detect@^4.0.5:
+type-detect@4.0.8, type-detect@^4.0.0, type-detect@^4.0.5, type-detect@^4.0.8:
   version "4.0.8"
   resolved "https://registry.yarnpkg.com/type-detect/-/type-detect-4.0.8.tgz#7646fb5f18871cfbb7749e69bd39a6388eb7450c"
   integrity sha512-0fr/mIH1dlO+x7TlcMy+bIDqKPsw/70tVyeHW787goQjhmqaZe10uwLujubK9q9Lg6Fiho1KUKDYz0Z7k7g5/g==

--- a/yarn.lock
+++ b/yarn.lock
@@ -1717,6 +1717,13 @@ cardinal@^1.0.0:
     ansicolors "~0.2.1"
     redeyed "~1.0.0"
 
+chai-as-promised@^7.1.1:
+  version "7.1.1"
+  resolved "https://registry.yarnpkg.com/chai-as-promised/-/chai-as-promised-7.1.1.tgz#08645d825deb8696ee61725dbf590c012eb00ca0"
+  integrity sha512-azL6xMoi+uxu6z4rhWQ1jbdUhOMhis2PvscD/xjLqNMkv3BPPp2JyyuTHOrf9BOosGpNQ11v6BKv/g57RXbiaA==
+  dependencies:
+    check-error "^1.0.2"
+
 chai@^4.3.4:
   version "4.3.4"
   resolved "https://registry.yarnpkg.com/chai/-/chai-4.3.4.tgz#b55e655b31e1eac7099be4c08c21964fce2e6c49"


### PR DESCRIPTION
pnpm versions 8.0.0 to 8.6.* had the `resolution-mode` setting inverted which caused troubles with unexpected versions of dependencies pulled for `ember-try` tests.

This is an attempt to fix those issues by enfrocing `resolution-mode=highest` via project-local `.npmrc`.