### PR TITLE
Support a `packageManager` option (instead of `usePnpm` and `useYarn`)

### DIFF
--- a/README.md
+++ b/README.md
@@ -116,15 +116,10 @@ module.exports = async function() {
     */
     useVersionCompatibility: true,
     /*
-      If set to true, all npm scenarios will use `yarn` for install with the `--no-lockfile` option. At cleanup, your
-      dependencies will be restored to their prior state.
+      The package manager to use for all scenarios. By default, lockfiles will be ignored when installing dependencies.
+      At cleanup, all dependencies will be restored to their prior state.
     */
-    useYarn: true,
-    /*
-      If set to true, all npm scenarios will use `pnpm` for install with the `--no-lockfile` options. At cleanup, your
-      dependencies will be restored to their prior state.
-    */
-    usePnpm: true,
+    packageManager: 'npm' | 'pnpm' | 'yarn',
 
     /*
       buildManagerOptions allows you to opt-out of the default options such as `--ignore-engines --no-lockfile`.
@@ -149,15 +144,15 @@ module.exports = async function() {
             'ember-source': '2.11.0'
           },
           /*
-            You can optionally define npm or pnpm overrides to enforce a  specific dependency version
+            You can optionally define npm or pnpm overrides to enforce a specific dependency version
             to be installed. This is useful if other libraries you depend on include different
-            versions of a package. This does nothing if `useYarn` is true;
+            versions of a package. This does nothing if `packageManager` is `yarn`;
           */
           overrides: {
             'lodash': '5.0.0'
           }
           /*
-            When `useYarn` is true, you can optionally define yarn resolutions to enforce a
+            When `packageManager` is `yarn`, you can optionally define yarn resolutions to enforce a
             specific dependency version to be installed. This is useful if other libraries
             you depend on include different versions of a package.
           */
@@ -209,11 +204,11 @@ The `name` can be used to try just one scenario using the `ember try:one` comman
 
 ##### Yarn
 
-If you include `useYarn: true` in your `ember-try` config, all npm scenarios will use `yarn` for install with the `--no-lockfile` option. At cleanup, your dependencies will be restored to their prior state.
+If you include `packageManager: 'yarn'` in your `ember-try` config, all npm scenarios will use `yarn` for install with the `--no-lockfile` option. At cleanup, your dependencies will be restored to their prior state.
 
 ##### Pnpm
 
-If you include `usePnpm: true` in your `ember-try` config, all npm scenarios will use `pnpm` for install with the `--no-lockfile` options. At cleanup, your dependencies will be restored to their prior state.
+If you include `packageManager: 'pnpm'` in your `ember-try` config, all npm scenarios will use `pnpm` for install with the `--no-lockfile` options. At cleanup, your dependencies will be restored to their prior state.
 
 > ⚠ pnpm versions from 8.0.0 to 8.6.x have the default value of [resolution-mode](https://pnpm.io/npmrc#resolution-mode) setting changed to `lowest-direct`. This violates `ember-try` expectations as `resolution-mode` is expected to be `highest`, like in `npm` and `pnpm` versions < 8.0.0 and >= 8.7.0.
 >

--- a/lib/dependency-manager-adapters/npm.js
+++ b/lib/dependency-manager-adapters/npm.js
@@ -68,7 +68,7 @@ module.exports = class {
         if (fs.statSync(path.join(this.cwd, this.yarnLock)).isFile()) {
           ui.writeLine(
             chalk.yellow(
-              'Detected a yarn.lock file. Add `useYarn: true` to your `config/ember-try.js` configuration file if you want to use Yarn to install npm dependencies.',
+              "Detected a yarn.lock file. Add `packageManager: 'yarn'` to your `config/ember-try.js` configuration file if you want to use Yarn to install npm dependencies.",
             ),
           );
         }

--- a/lib/dependency-manager-adapters/workspace.js
+++ b/lib/dependency-manager-adapters/workspace.js
@@ -19,7 +19,7 @@ module.exports = class {
 
     if (!this.useYarnCommand) {
       throw new Error(
-        'workspaces are currently only supported by Yarn, you must set `useYarn` to true',
+        'workspaces are currently only supported by Yarn, you must set `packageManager` to `yarn`',
       );
     }
     let packageJSON = JSON.parse(fs.readFileSync(this.packageJSON));

--- a/lib/utils/config.js
+++ b/lib/utils/config.js
@@ -1,5 +1,6 @@
 'use strict';
 
+const chalk = require('chalk');
 const path = require('path');
 const fs = require('fs');
 const findByName = require('./find-by-name');
@@ -61,6 +62,24 @@ async function getBaseConfig(options) {
 
 async function config(options) {
   const configData = await getBaseConfig(options);
+
+  for (const packageManager of [
+    ['pnpm', 'usePnpm'],
+    ['yarn', 'useYarn'],
+  ]) {
+    const [name, oldOption] = packageManager;
+
+    if (typeof configData[oldOption] === 'boolean') {
+      console.warn(
+        chalk.yellow(
+          `${chalk.inverse(' ember-try DEPRECATION ')} The \`${oldOption}\` config option is deprecated. Please use \`packageManager: '${name}'\` instead.`,
+        ),
+      );
+
+      delete configData[oldOption];
+      configData.packageManager = name;
+    }
+  }
 
   return configData;
 }

--- a/lib/utils/dependency-manager-adapter-factory.js
+++ b/lib/utils/dependency-manager-adapter-factory.js
@@ -23,11 +23,11 @@ module.exports = {
         new WorkspaceAdapter({
           cwd: root,
           managerOptions: config.npmOptions,
-          useYarnCommand: config.useYarn,
+          useYarnCommand: config.packageManager === 'yarn',
           buildManagerOptions: config.buildManagerOptions,
         }),
       );
-    } else if (config.usePnpm) {
+    } else if (config.packageManager === 'pnpm') {
       adapters.push(
         new PnpmAdapter({
           cwd: root,
@@ -40,7 +40,7 @@ module.exports = {
         new NpmAdapter({
           cwd: root,
           managerOptions: config.npmOptions,
-          useYarnCommand: config.useYarn,
+          useYarnCommand: config.packageManager === 'yarn',
           buildManagerOptions: config.buildManagerOptions,
         }),
       );

--- a/test/dependency-manager-adapters/workspace-adapter-test.js
+++ b/test/dependency-manager-adapters/workspace-adapter-test.js
@@ -124,7 +124,7 @@ describe('workspaceAdapter', () => {
             cwd: tmpdir,
           });
         }).to.throw(
-          /workspaces are currently only supported by Yarn, you must set `useYarn` to true/,
+          /workspaces are currently only supported by Yarn, you must set `packageManager` to `yarn`/,
         );
       });
     });

--- a/test/fixtures/dummy-ember-try-config-with-yarn-scenarios.js
+++ b/test/fixtures/dummy-ember-try-config-with-yarn-scenarios.js
@@ -1,5 +1,5 @@
 module.exports = {
-  useYarn: true,
+  packageManager: 'yarn',
   scenarios: [
     {
       name: 'test2',

--- a/test/tasks/try-each-test.js
+++ b/test/tasks/try-each-test.js
@@ -97,7 +97,7 @@ describe('tryEach', () => {
       return tryEachTask.run(config.scenarios, {}).then((exitCode) => {
         expect(exitCode).to.equal(0, 'exits 0 when all scenarios succeed');
         expect(output).to.include(
-          'Detected a yarn.lock file. Add `useYarn: true` to your `config/ember-try.js` configuration file if you want to use Yarn to install npm dependencies.',
+          "Detected a yarn.lock file. Add `packageManager: 'yarn'` to your `config/ember-try.js` configuration file if you want to use Yarn to install npm dependencies.",
         );
         expect(output).to.include('Scenario first: SUCCESS');
         expect(output).to.include('Scenario second: SUCCESS');

--- a/test/utils/config-test.js
+++ b/test/utils/config-test.js
@@ -240,6 +240,32 @@ describe('utils/config', () => {
       });
     });
   });
+
+  describe('old package-manager options', () => {
+    it("replaces `usePnpm` with `packageManager: 'pnpm'`", () => {
+      generateConfigFile(
+        'module.exports = { usePnpm: true, scenarios: [] };',
+        'config/use-pnpm.js',
+      );
+
+      return getConfig({ configPath: 'config/use-pnpm.js', project }).then((config) => {
+        expect(config.usePnpm).to.be.undefined;
+        expect(config.packageManager).to.be.equal('pnpm');
+      });
+    });
+
+    it("replaces `useYarn` with `packageManager: 'yarn'`", () => {
+      generateConfigFile(
+        'module.exports = { useYarn: true, scenarios: [] };',
+        'config/use-yarn.js',
+      );
+
+      return getConfig({ configPath: 'config/use-yarn.js', project }).then((config) => {
+        expect(config.useYarn).to.be.undefined;
+        expect(config.packageManager).to.be.equal('yarn');
+      });
+    });
+  });
 });
 
 function writePackageJSONWithVersionCompatibility() {

--- a/test/utils/dependency-manager-adapter-factory-test.js
+++ b/test/utils/dependency-manager-adapter-factory-test.js
@@ -43,7 +43,7 @@ describe('DependencyManagerAdapterFactory', () => {
 
       let adapters = DependencyManagerAdapterFactory.generateFromConfig(
         {
-          useYarn: true,
+          packageManager: 'yarn',
           useWorkspaces: true,
           scenarios: [{ npm: {} }],
         },


### PR DESCRIPTION
So we have just one option to determine the desired package manager, instead of two (`usePnpm` and `useYarn`).
It's also a bit unclear what happens if you use both of them, or set them to `false`.
This also simplifies [this bit](https://github.com/ember-cli/ember-cli/blob/master/blueprints/addon/files/addon-config/ember-try.js#L8-L9) in the blueprints, as we can write `packageManager: '<%= packageManager %>'` instead.