### PR TITLE
Remove use of `mockery`

### DIFF
--- a/lib/utils/run.js
+++ b/lib/utils/run.js
@@ -3,7 +3,9 @@
 const execa = require('execa');
 const debug = require('debug')('ember-try:utils:run');
 
-module.exports = async function run(command, args, _options) {
+let runFunction = originalRunFunction;
+
+async function originalRunFunction(command, args, _options) {
   let options = Object.assign({ stdio: 'inherit', shell: true }, _options);
 
   if (process.env.SHUT_UP) {
@@ -21,4 +23,22 @@ module.exports = async function run(command, args, _options) {
     // TODO: should refactor this to throw an error (easier to track down stack traces)
     throw error.exitCode;
   }
-};
+}
+
+function run(command, args, options) {
+  return runFunction(command, args, options);
+}
+
+function mockRun(mockedRunFunction) {
+  runFunction = mockedRunFunction;
+}
+
+function restoreRun() {
+  runFunction = originalRunFunction;
+}
+
+module.exports = run;
+
+module.exports._originalRunFunction = originalRunFunction;
+module.exports._mockRun = mockRun;
+module.exports._restoreRun = restoreRun;

--- a/package.json
+++ b/package.json
@@ -60,7 +60,6 @@
     "eslint-config-prettier": "^9.1.0",
     "eslint-plugin-n": "^17.15.0",
     "mocha": "^10.8.2",
-    "mockery": "^2.1.0",
     "nyc": "^17.1.0",
     "prettier": "^3.3.3",
     "release-it": "^17.10.0",

--- a/test/helpers/generate-mock-run.js
+++ b/test/helpers/generate-mock-run.js
@@ -1,5 +1,7 @@
 'use strict';
 
+const { _originalRunFunction } = require('../../lib/utils/run');
+
 module.exports = function generateMockRun() {
   let mockedRuns = [];
   let options = { allowPassthrough: true };
@@ -39,7 +41,7 @@ function isCommandMocked(mockedRun, actualCommand, actualArgs) {
 }
 
 function passthrough() {
-  return require('../../lib/utils/run');
+  return _originalRunFunction;
 }
 
 function mockedCommandIsEmberAndArgumentsMatch(

--- a/test/tasks/try-each-test.js
+++ b/test/tasks/try-each-test.js
@@ -6,7 +6,7 @@ const path = require('path');
 const fs = require('fs-extra');
 const fixturePackage = require('../fixtures/package.json');
 const writeJSONFile = require('../helpers/write-json-file');
-const mockery = require('mockery');
+const { _mockRun, _restoreRun } = require('../../lib/utils/run');
 
 /* Some of the tests in this file intentionally DO NOT stub dependency manager adapter*/
 const StubDependencyAdapter = require('../helpers/stub-dependency-manager-adapter');
@@ -53,16 +53,11 @@ describe('tryEach', () => {
   beforeEach(() => {
     tmpdir = tmp.in(tmproot);
     process.chdir(tmpdir);
-    mockery.enable({
-      warnOnUnregistered: false,
-      useCleanCache: true,
-    });
     require('chalk').level = 0;
   });
 
   afterEach(() => {
-    mockery.deregisterAll();
-    mockery.disable();
+    _restoreRun();
     process.chdir(root);
     return fs.remove(tmproot);
   });
@@ -75,7 +70,7 @@ describe('tryEach', () => {
         return Promise.resolve(0);
       });
 
-      mockery.registerMock('./run', mockedRun);
+      _mockRun(mockedRun);
 
       let output = [];
       let outputFn = function (log) {
@@ -130,7 +125,7 @@ describe('tryEach', () => {
         }
       });
 
-      mockery.registerMock('./run', mockedRun);
+      _mockRun(mockedRun);
 
       let output = [];
       let outputFn = function (log) {
@@ -194,7 +189,8 @@ describe('tryEach', () => {
           },
         },
       ]);
-      mockery.registerMock('./run', mockedRun);
+
+      _mockRun(mockedRun);
 
       let output = [];
       let outputFn = function (log) {
@@ -242,7 +238,7 @@ describe('tryEach', () => {
         return Promise.resolve(0);
       });
 
-      mockery.registerMock('./run', mockedRun);
+      _mockRun(mockedRun);
 
       let output = [];
       let outputFn = function (log) {
@@ -295,7 +291,8 @@ describe('tryEach', () => {
         let mockedRun = generateMockRun('ember test', () => {
           return Promise.reject(1);
         });
-        mockery.registerMock('./run', mockedRun);
+
+        _mockRun(mockedRun);
 
         let output = [];
         let outputFn = function (log) {
@@ -345,7 +342,8 @@ describe('tryEach', () => {
         let mockedRun = generateMockRun('ember test', () => {
           return Promise.reject(1);
         });
-        mockery.registerMock('./run', mockedRun);
+
+        _mockRun(mockedRun);
 
         let output = [];
         let outputFn = function (log) {
@@ -396,7 +394,8 @@ describe('tryEach', () => {
         let mockedRun = generateMockRun('ember test', () => {
           return Promise.resolve(0);
         });
-        mockery.registerMock('./run', mockedRun);
+
+        _mockRun(mockedRun);
 
         let output = [];
         let outputFn = function (log) {
@@ -451,7 +450,7 @@ describe('tryEach', () => {
           return Promise.resolve(0);
         });
 
-        mockery.registerMock('./run', mockedRun);
+        _mockRun(mockedRun);
 
         let output = [];
         let outputFn = function (log) {
@@ -498,7 +497,8 @@ describe('tryEach', () => {
           ranPassedInCommand = true;
           return Promise.resolve(0);
         });
-        mockery.registerMock('./run', mockedRun);
+
+        _mockRun(mockedRun);
 
         let output = [];
         let outputFn = function (log) {
@@ -570,7 +570,8 @@ describe('tryEach', () => {
             },
           },
         ]);
-        mockery.registerMock('./run', mockedRun);
+
+        _mockRun(mockedRun);
 
         let output = [];
         let outputFn = function (log) {
@@ -673,7 +674,8 @@ describe('tryEach', () => {
           actualOptions.push(opts);
           return Promise.resolve(0);
         });
-        mockery.registerMock('./run', mockedRun);
+
+        _mockRun(mockedRun);
 
         let output = [];
         let outputFn = function (log) {

--- a/test/utils/run-command-test.js
+++ b/test/utils/run-command-test.js
@@ -1,19 +1,11 @@
 'use strict';
 
 const expect = require('chai').expect;
-const mockery = require('mockery');
+const { _mockRun, _restoreRun } = require('../../lib/utils/run');
 
 describe('utils/run-command', () => {
-  beforeEach(() => {
-    mockery.enable({
-      warnOnUnregistered: false,
-      useCleanCache: true,
-    });
-  });
-
   afterEach(() => {
-    mockery.deregisterAll();
-    mockery.disable();
+    _restoreRun();
   });
 
   it('passes arguments to run', () => {
@@ -26,7 +18,7 @@ describe('utils/run-command', () => {
       return Promise.resolve(0);
     };
 
-    mockery.registerMock('./run', mockedRun);
+    _mockRun(mockedRun);
 
     let runCommand = require('../../lib/utils/run-command');
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -6328,11 +6328,6 @@ mocha@^10.8.2:
     yargs-parser "^20.2.9"
     yargs-unparser "^2.0.0"
 
-mockery@^2.1.0:
-  version "2.1.0"
-  resolved "https://registry.yarnpkg.com/mockery/-/mockery-2.1.0.tgz#5b0aef1ff564f0f8139445e165536c7909713470"
-  integrity sha512-9VkOmxKlWXoDO/h1jDZaS4lH33aWfRiJiNT/tKj+8OGzrcFDLo8d0syGdbsc3Bc4GvRXPb+NMMvojotmuGJTvA==
-
 morgan@^1.10.0:
   version "1.10.0"
   resolved "https://registry.yarnpkg.com/morgan/-/morgan-1.10.0.tgz#091778abc1fc47cd3509824653dae1faab6b17d7"


### PR DESCRIPTION
The `mockery` project is old, and archived.
I also had some issues with it when converting the test suite to ES modules, so seemed easiest to just get rid of it, and use a more "vanilla" approach.