### PR TITLE
Don't use ember-cli `project` instance outside of ember-cli commands

### DIFF
--- a/lib/commands/config.js
+++ b/lib/commands/config.js
@@ -12,9 +12,10 @@ module.exports = {
   async run(commandOptions) {
     debug('Options:\n', commandOptions);
 
+    let cwd = this.project.root;
     let config = await require('../utils/config')({
-      project: this.project,
       configPath: commandOptions.configPath,
+      cwd,
     });
 
     log(JSON.stringify(config, null, 2));

--- a/lib/commands/reset.js
+++ b/lib/commands/reset.js
@@ -6,12 +6,13 @@ module.exports = {
   works: 'insideProject',
 
   async run() {
-    let config = await require('../utils/config')({ project: this.project });
+    let cwd = this.project.root;
+    let config = await require('../utils/config')({ cwd });
     let ResetTask = require('../tasks/reset');
 
     let resetTask = new ResetTask({
-      project: this.project,
       config,
+      cwd,
     });
 
     return await resetTask.run();

--- a/lib/commands/try-each.js
+++ b/lib/commands/try-each.js
@@ -18,16 +18,17 @@ module.exports = {
   async run(commandOptions) {
     debug('Options:\n', commandOptions);
 
+    let cwd = this.project.root;
     let config = await this._getConfig({
-      project: this.project,
       configPath: commandOptions.configPath,
+      cwd,
     });
 
     debug('Config: %s', JSON.stringify(config));
 
     let tryEachTask = new this._TryEachTask({
-      project: this.project,
       config,
+      cwd,
     });
 
     return await tryEachTask.run(config.scenarios, { skipCleanup: commandOptions.skipCleanup });

--- a/lib/commands/try-ember.js
+++ b/lib/commands/try-ember.js
@@ -24,9 +24,10 @@ module.exports = {
     debug('Options:\n', commandOptions);
     debug('Ember semver statement', emberVersion);
 
+    let cwd = this.project.root;
     let config = await this._getConfig({
-      project: this.project,
       configPath: commandOptions.configPath,
+      cwd,
       versionCompatibility: {
         ember: emberVersion,
       },
@@ -35,8 +36,8 @@ module.exports = {
     debug('Config: %s', JSON.stringify(config));
 
     let tryEachTask = new this._TryEachTask({
-      project: this.project,
       config,
+      cwd,
     });
 
     return await tryEachTask.run(config.scenarios, { skipCleanup: commandOptions.skipCleanup });

--- a/lib/commands/try-one.js
+++ b/lib/commands/try-one.js
@@ -42,9 +42,10 @@ module.exports = {
       throw new Error('The `ember try:one` command requires a ' + 'scenario name to be specified.');
     }
 
+    let cwd = this.project.root;
     let config = await this._getConfig({
-      project: this.project,
       configPath: commandOptions.configPath,
+      cwd,
     });
 
     debug('Config: %s', JSON.stringify(config));
@@ -57,9 +58,9 @@ module.exports = {
     }
 
     let tryEachTask = new this._TryEachTask({
-      project: this.project,
-      config,
       commandArgs,
+      config,
+      cwd,
     });
 
     return await tryEachTask.run([scenario], { skipCleanup: commandOptions.skipCleanup });

--- a/lib/tasks/reset.js
+++ b/lib/tasks/reset.js
@@ -7,13 +7,13 @@ const DependencyManagerAdapterFactory = require('./../utils/dependency-manager-a
 module.exports = class ResetTask {
   constructor(options) {
     this.config = options.config;
-    this.project = options.project;
+    this.cwd = options.cwd;
   }
 
   run() {
     let dependencyAdapters = DependencyManagerAdapterFactory.generateFromConfig(
       this.config,
-      this.project.root,
+      this.cwd,
     );
     debug(
       'DependencyManagerAdapters: %s',

--- a/lib/tasks/try-each.js
+++ b/lib/tasks/try-each.js
@@ -9,8 +9,8 @@ module.exports = class TryEachTask {
     this.commandArgs = options.commandArgs;
     this.commandOptions = options.commandOptions;
     this.config = options.config;
+    this.cwd = options.cwd;
     this.dependencyManagerAdapters = options.dependencyManagerAdapters;
-    this.project = options.project;
   }
 
   async run(scenarios, options) {
@@ -21,7 +21,7 @@ module.exports = class TryEachTask {
 
     let dependencyManagerAdapters =
       this.dependencyManagerAdapters ||
-      DependencyManagerAdapterFactory.generateFromConfig(this.config, this.project.root);
+      DependencyManagerAdapterFactory.generateFromConfig(this.config, this.cwd);
     debug(
       'DependencyManagerAdapters: %s',
       dependencyManagerAdapters.map((item) => {
@@ -134,7 +134,7 @@ module.exports = class TryEachTask {
   }
 
   _runCommand(options) {
-    return runCommand(this.project.root, options.commandArgs, options.commandOptions);
+    return runCommand(this.cwd, options.commandArgs, options.commandOptions);
   }
 
   _commandOptions(env) {

--- a/lib/utils/config.js
+++ b/lib/utils/config.js
@@ -5,12 +5,12 @@ const fs = require('fs');
 const { prefix, warn } = require('./console');
 const debug = require('debug')('ember-try:utils:config');
 
-function getConfigPath(project) {
+function getConfigPath(cwd) {
+  let packageFile = readPackageFile(cwd);
   let possibleConfigPath;
-  if (project.pkg && project.pkg['ember-addon'] && project.pkg['ember-addon']['configPath']) {
-    let configDir = project.pkg['ember-addon']['configPath'];
 
-    possibleConfigPath = path.join(configDir, 'ember-try.js');
+  if (packageFile['ember-addon']?.['configPath']) {
+    possibleConfigPath = path.join(packageFile['ember-addon']['configPath'], 'ember-try.js');
   }
 
   if (fs.existsSync(possibleConfigPath)) {
@@ -25,8 +25,8 @@ function getConfigPath(project) {
 }
 
 async function getBaseConfig(options) {
-  let relativeConfigPath = options.configPath || getConfigPath(options.project);
-  let configPath = path.join(options.project.root, relativeConfigPath);
+  let relativeConfigPath = options.configPath || getConfigPath(options.cwd);
+  let configPath = path.join(options.cwd, relativeConfigPath);
   let data;
 
   if (fs.existsSync(configPath)) {
@@ -42,14 +42,13 @@ async function getBaseConfig(options) {
   }
 
   let versionCompatibility =
-    options.versionCompatibility || versionCompatibilityFromPackageJSON(options.project.root);
+    options.versionCompatibility || versionCompatibilityFromPackageJSON(options.cwd);
   if (versionCompatibility) {
     // Required lazily to improve startup speed.
     let autoScenarioConfigForEmber = require('ember-try-config');
 
     let autoConfig = await autoScenarioConfigForEmber({
       versionCompatibility,
-      project: options.project,
     });
     return await mergeAutoConfigAndConfigFileData(autoConfig, data);
   } else {
@@ -103,11 +102,18 @@ function mergeAutoConfigAndConfigFileData(autoConfig, configData) {
   return conf;
 }
 
-function versionCompatibilityFromPackageJSON(root) {
-  let packageJSONFile = path.join(root, 'package.json');
-  if (fs.existsSync(packageJSONFile)) {
-    let packageJSON = JSON.parse(fs.readFileSync(packageJSONFile));
+function versionCompatibilityFromPackageJSON(cwd) {
+  let packageFile = readPackageFile(cwd);
 
-    return packageJSON['ember-addon'] ? packageJSON['ember-addon'].versionCompatibility : null;
+  return packageFile['ember-addon']?.versionCompatibility ?? null;
+}
+
+function readPackageFile(cwd) {
+  let packageFile = path.join(cwd, 'package.json');
+
+  if (fs.existsSync(packageFile)) {
+    return JSON.parse(fs.readFileSync(packageFile));
+  } else {
+    return {};
   }
 }

--- a/lib/utils/dependency-manager-adapter-factory.js
+++ b/lib/utils/dependency-manager-adapter-factory.js
@@ -6,7 +6,7 @@ const WorkspaceAdapter = require('../dependency-manager-adapters/workspace');
 const YarnAdapter = require('../dependency-manager-adapters/yarn');
 
 module.exports = {
-  generateFromConfig(config, root) {
+  generateFromConfig(config, cwd) {
     let hasNpm = false;
     let adapters = [];
     if (!config || !config.scenarios) {
@@ -22,7 +22,7 @@ module.exports = {
     if (config.useWorkspaces) {
       adapters.push(
         new WorkspaceAdapter({
-          cwd: root,
+          cwd,
           managerOptions: config.npmOptions,
           packageManager: config.packageManager,
           buildManagerOptions: config.buildManagerOptions,
@@ -31,7 +31,7 @@ module.exports = {
     } else if (config.packageManager === 'pnpm') {
       adapters.push(
         new PnpmAdapter({
-          cwd: root,
+          cwd,
           managerOptions: config.npmOptions,
           buildManagerOptions: config.buildManagerOptions,
         }),
@@ -39,7 +39,7 @@ module.exports = {
     } else if (config.packageManager === 'yarn') {
       adapters.push(
         new YarnAdapter({
-          cwd: root,
+          cwd,
           managerOptions: config.npmOptions,
           buildManagerOptions: config.buildManagerOptions,
         }),
@@ -47,7 +47,7 @@ module.exports = {
     } else if (hasNpm) {
       adapters.push(
         new NpmAdapter({
-          cwd: root,
+          cwd,
           managerOptions: config.npmOptions,
           buildManagerOptions: config.buildManagerOptions,
         }),

--- a/test/commands/try-each-test.js
+++ b/test/commands/try-each-test.js
@@ -12,6 +12,8 @@ describe('commands/try-each', () => {
     MockTryEachTask.prototype.run = function () {};
 
     beforeEach(() => {
+      TryEachCommand.project = { root: '' };
+
       TryEachCommand._getConfig = function () {
         return Promise.resolve(mockConfig || { scenarios: [] });
       };
@@ -20,6 +22,8 @@ describe('commands/try-each', () => {
     });
 
     afterEach(() => {
+      delete TryEachCommand.project;
+
       TryEachCommand._TryEachTask = origTryEachTask;
       TryEachCommand._getConfig = origGetConfig;
       mockConfig = null;

--- a/test/commands/try-ember-test.js
+++ b/test/commands/try-ember-test.js
@@ -12,6 +12,8 @@ describe('commands/try-ember', () => {
     MockTryEachTask.prototype.run = function () {};
 
     beforeEach(() => {
+      TryEmberCommand.project = { root: '' };
+
       TryEmberCommand._getConfig = function () {
         return Promise.resolve(mockConfig || { scenarios: [] });
       };
@@ -20,6 +22,8 @@ describe('commands/try-ember', () => {
     });
 
     afterEach(() => {
+      delete TryEmberCommand.project;
+
       TryEmberCommand._TryEachTask = origTryEachTask;
       TryEmberCommand._getConfig = origGetConfig;
       mockConfig = null;

--- a/test/commands/try-one-test.js
+++ b/test/commands/try-one-test.js
@@ -37,6 +37,8 @@ describe('commands/try-one', () => {
     MockTryEachTask.prototype.run = function () {};
 
     beforeEach(() => {
+      TryOneCommand.project = { root: '' };
+
       TryOneCommand._getConfig = function () {
         return Promise.resolve(mockConfig || { scenarios: [] });
       };
@@ -45,6 +47,8 @@ describe('commands/try-one', () => {
     });
 
     afterEach(() => {
+      delete TryOneCommand.project;
+
       TryOneCommand._TryEachTask = origTryEachTask;
       TryOneCommand._getConfig = origGetConfig;
       mockConfig = null;

--- a/test/tasks/reset-test.js
+++ b/test/tasks/reset-test.js
@@ -37,8 +37,8 @@ describe('reset', () => {
     };
 
     let resetTask = new ResetTask({
-      project: { root: tmpdir },
       config,
+      cwd: tmpdir,
     });
 
     writeJSONFile('package.json', fixturePackageJson);

--- a/test/tasks/try-each-test.js
+++ b/test/tasks/try-each-test.js
@@ -83,8 +83,8 @@ describe('tryEach', () => {
       _mockLog(outputFn);
 
       let tryEachTask = new TryEachTask({
-        project: { root: tmpdir },
         config,
+        cwd: tmpdir,
       });
 
       tryEachTask._on = () => {};
@@ -138,8 +138,8 @@ describe('tryEach', () => {
       _mockLog(outputFn);
 
       let tryEachTask = new TryEachTask({
-        project: { root: tmpdir },
         config,
+        cwd: tmpdir,
       });
 
       tryEachTask._on = () => {};
@@ -203,8 +203,8 @@ describe('tryEach', () => {
       _mockLog(outputFn);
 
       let tryEachTask = new TryEachTask({
-        project: { root: tmpdir },
         config,
+        cwd: tmpdir,
         dependencyManagerAdapters: [],
       });
 
@@ -251,8 +251,8 @@ describe('tryEach', () => {
       _mockLog(outputFn);
 
       let tryEachTask = new TryEachTask({
-        project: { root: tmpdir },
         config,
+        cwd: tmpdir,
         commandArgs: ['ember', 'serve'],
         commandOptions: { timeout: { length: 20000, isSuccess: true } },
         dependencyManagerAdapters: [new StubDependencyAdapter()],
@@ -305,8 +305,8 @@ describe('tryEach', () => {
         _mockLog(outputFn);
 
         let tryEachTask = new TryEachTask({
-          project: { root: tmpdir },
           config,
+          cwd: tmpdir,
           dependencyManagerAdapters: [new StubDependencyAdapter()],
         });
 
@@ -356,8 +356,8 @@ describe('tryEach', () => {
         _mockLog(outputFn);
 
         let tryEachTask = new TryEachTask({
-          project: { root: tmpdir },
           config,
+          cwd: tmpdir,
           dependencyManagerAdapters: [new StubDependencyAdapter()],
         });
 
@@ -408,8 +408,8 @@ describe('tryEach', () => {
         _mockLog(outputFn);
 
         let tryEachTask = new TryEachTask({
-          project: { root: tmpdir },
           config,
+          cwd: tmpdir,
           dependencyManagerAdapters: [new StubDependencyAdapter()],
         });
 
@@ -463,8 +463,8 @@ describe('tryEach', () => {
         _mockLog(outputFn);
 
         let tryEachTask = new TryEachTask({
-          project: { root: tmpdir },
           config,
+          cwd: tmpdir,
           commandArgs: [],
           dependencyManagerAdapters: [new StubDependencyAdapter()],
         });
@@ -511,8 +511,8 @@ describe('tryEach', () => {
         _mockLog(outputFn);
 
         let tryEachTask = new TryEachTask({
-          project: { root: tmpdir },
           config,
+          cwd: tmpdir,
           commandArgs: ['ember', 'serve'],
           dependencyManagerAdapters: [new StubDependencyAdapter()],
         });
@@ -584,8 +584,8 @@ describe('tryEach', () => {
         _mockLog(outputFn);
 
         let tryEachTask = new TryEachTask({
-          project: { root: tmpdir },
           config,
+          cwd: tmpdir,
           dependencyManagerAdapters: [new StubDependencyAdapter()],
         });
 
@@ -632,8 +632,8 @@ describe('tryEach', () => {
         _mockLog(outputFn);
 
         let tryEachTask = new TryEachTask({
-          project: { root: tmpdir },
           config,
+          cwd: tmpdir,
           commandArgs: ['ember', 'version', '--verbose', 'true'],
           dependencyManagerAdapters: [new StubDependencyAdapter()],
         });
@@ -688,8 +688,8 @@ describe('tryEach', () => {
         _mockLog(outputFn);
 
         let tryEachTask = new TryEachTask({
-          project: { root: tmpdir },
           config,
+          cwd: tmpdir,
           dependencyManagerAdapters: [new StubDependencyAdapter()],
         });
 
@@ -742,8 +742,8 @@ describe('tryEach', () => {
       };
 
       let tryEachTask = new TryEachTask({
-        project: { root: tmpdir },
         config,
+        cwd: tmpdir,
         dependencyManagerAdapters: [new StubDependencyAdapter()],
       });
 


### PR DESCRIPTION
Part of decoupling `ember-try` from `ember-cli`.

This way, only the code in `lib/commands` is coupled to `ember-cli`.
The next step would be to move the `run` portion of the commands to separate files.
This would allow us to move everything to ES modules, except the commands.
The commands can async import and run the ES modules.