### PR TITLE
Remove passing an ember-cli `project` instance to the config function

### DIFF
--- a/lib/utils/config.js
+++ b/lib/utils/config.js
@@ -32,7 +32,7 @@ async function getBaseConfig(options) {
   if (fs.existsSync(configPath)) {
     let configData = await require(configPath);
 
-    data = typeof configData === 'function' ? await configData(options.project) : configData;
+    data = typeof configData === 'function' ? await configData() : configData;
   } else {
     debug('Config file does not exist %s', configPath);
   }

--- a/test/utils/config-test.js
+++ b/test/utils/config-test.js
@@ -108,18 +108,6 @@ describe('utils/config', () => {
     });
   });
 
-  it('config file exporting a function is passed the project', () => {
-    generateConfigFile(
-      'module.exports =  function(project) { return { scenarios: [ { foo: project.blah }] } };',
-    );
-
-    project.blah = 'passed-in';
-    return getConfig({ project }).then((config) => {
-      expect(config.scenarios).to.have.lengthOf(1);
-      expect(config.scenarios[0].foo).to.equal('passed-in');
-    });
-  });
-
   it('throws error if project.root/config/ember-try.js is not present and no versionCompatibility', () => {
     return getConfig({ project }).catch((error) => {
       expect(error).to.match(


### PR DESCRIPTION
I suspect (almost) no users will be affected by this.
If someone does run into this, feel free to give me a ping,
and I will try to suggest a proper migration path.