### PR TITLE
use package.json pnpm version for release-plan

### DIFF
--- a/.github/workflows/plan-release.yml
+++ b/.github/workflows/plan-release.yml
@@ -53,8 +53,6 @@ jobs:
           fetch-depth: 0
           ref: 'main'
       - uses: pnpm/action-setup@v4
-        with:
-          version: 9
       - uses: actions/setup-node@v4
         with:
           node-version: 18

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -47,8 +47,6 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - uses: pnpm/action-setup@v4
-        with:
-          version: 9
       - uses: actions/setup-node@v4
         with:
           node-version: 18


### PR DESCRIPTION
The rare thing happened! two PRs that affected each other were merged without rebasing 🫠 https://github.com/ember-cli/ember-try/pull/1049 means that https://github.com/ember-cli/ember-try/pull/1039 should not have specified pnpm versions in the github jobs

No big deal, this PR fixes that 🎉 