### PR TITLE
Support ember-try.cjs

### DIFF
--- a/lib/utils/config.js
+++ b/lib/utils/config.js
@@ -19,6 +19,14 @@ function getConfigPath(cwd) {
     return possibleConfigPath;
   }
 
+  let cjsPath = path.join('config', 'ember-try.cjs');
+
+  if (fs.existsSync(cjsPath)) {
+    debug(`using config from config/ember-try.cjs`);
+
+    return cjs;
+  }
+
   debug('using config from config/ember-try.js');
 
   return path.join('config', 'ember-try.js');
@@ -53,7 +61,7 @@ async function getBaseConfig(options) {
     return await mergeAutoConfigAndConfigFileData(autoConfig, data);
   } else {
     throw new Error(
-      'No ember-try configuration found. Please see the README for configuration options',
+      'No ember-try configuration found. Please see the README for configuration options'
     );
   }
 }
@@ -69,7 +77,9 @@ async function config(options) {
 
     if (typeof configData[oldOption] === 'boolean') {
       warn(
-        `${prefix('ember-try DEPRECATION')} The \`${oldOption}\` config option is deprecated. Please use \`packageManager: '${name}'\` instead.`,
+        `${prefix(
+          'ember-try DEPRECATION'
+        )} The \`${oldOption}\` config option is deprecated. Please use \`packageManager: '${name}'\` instead.`
       );
 
       delete configData[oldOption];


### PR DESCRIPTION
in a type=module project, ember-try.js cannot use require, because js is an ESM 